### PR TITLE
Improve map UI with track view toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,21 +43,37 @@
       }
     </style>
   </head>
-  <body class="bg-gray-900 text-gray-100">
-    <div id="map"></div>
-
-    <!-- Metric toggle -->
-    <div
-      class="fixed top-4 right-4 bg-gray-800/80 backdrop-blur-sm shadow-xl rounded-2xl px-4 py-3 flex items-center gap-3 z-[1000] text-sm"
+  <body class="bg-gray-900 text-gray-200">
+    <button
+      id="toggleSidebar"
+      class="fixed top-4 left-4 bg-gray-800/80 text-gray-100 p-2 rounded-md md:hidden z-[1001]"
     >
-      <span class="font-medium">Metric:</span>
-      <select
-        id="metricSelect"
-        class="bg-gray-700 border border-gray-600 rounded-md px-2 py-1 focus:outline-none"
+      ☰
+    </button>
+    <div class="flex h-screen">
+      <div id="map" class="flex-1"></div>
+      <aside
+        id="sidebar"
+        class="fixed top-0 left-0 h-full w-72 max-w-full bg-gray-800/90 backdrop-blur-md p-4 space-y-4 overflow-y-auto transform -translate-x-full transition-transform z-[1000] md:relative md:translate-x-0 md:w-72 md:bg-opacity-100 text-gray-200"
       >
-        <option value="dose">Dose (µSv/h)</option>
-        <option value="cps">Counts (cps)</option>
-      </select>
+        <h2 class="text-lg font-semibold mb-2">Tracks</h2>
+        <ul id="trackList" class="space-y-2 text-sm"></ul>
+        <div>
+          <label for="metricSelect" class="block mb-1 font-medium">Metric</label>
+          <select
+            id="metricSelect"
+            class="bg-gray-700 border border-gray-600 rounded-md px-2 py-1 w-full focus:outline-none"
+          >
+            <option value="dose">Dose (µSv/h)</option>
+            <option value="cps">Counts (cps)</option>
+          </select>
+        </div>
+        <div>
+          <label class="flex items-center gap-2 text-gray-200" for="trackViewToggle">
+            <input type="checkbox" id="trackViewToggle" class="accent-blue-500" /> Track view
+          </label>
+        </div>
+      </aside>
     </div>
 
     <script>
@@ -86,8 +102,18 @@
 
         /* ------------------ STATE ------------------ */
         const allPoints = [];
+        const tracks = {};
         const pointLayer = L.layerGroup().addTo(map);
         const lineLayer = L.layerGroup().addTo(map);
+        const trackListElem = document.getElementById("trackList");
+        const sidebar = document.getElementById("sidebar");
+        const trackViewToggle = document.getElementById("trackViewToggle");
+        let trackView = false;
+        document
+          .getElementById("toggleSidebar")
+          .addEventListener("click", () =>
+            sidebar.classList.toggle("-translate-x-full")
+          );
 
         /* ------------------ HELPERS ------------------ */
         const fetchTrackList = async () => {
@@ -163,15 +189,19 @@
               // line: connect sequentially (no closing) – original method
               const path = pts.map((p) => [p.lat, p.lon]);
               const line = L.polyline(path, {
-                color: "#38bdf8",
+                color: "#facc15",
                 weight: 3,
-                opacity: 0.4,
-              }).addTo(lineLayer);
+                opacity: 0.7,
+              });
+              tracks[fname] = { points: pts, line, visible: true };
+              const li = document.createElement("li");
+              li.innerHTML =
+                `<label class='flex items-center gap-2 text-gray-200'><input type='checkbox' class='trackCheck accent-blue-500' data-file='${fname}' checked> ${fname.split("/").pop()}</label>`;
+              trackListElem.appendChild(li);
 
               // statistics
               const doses = pts.map((p) => p.dose);
               const cpses = pts.map((p) => p.cps);
-              const energies = pts.map((p) => p.energy).filter((v) => !isNaN(v));
               const stats = {
                 avgDose: doses.reduce((a, b) => a + b, 0) / doses.length,
                 minDose: Math.min(...doses),
@@ -199,7 +229,7 @@
                       <label class='block text-xs mb-1'>Avg window: <span id='val-${uid}'>1</span></label>
                       <input type='range' min='1' max='50' value='1' id='${sliderId}' class='w-full mb-2'>
                       <div id='${plotId}' style='width:384px;height:220px;'></div>
-                      <h4 class='mt-3 text-sm font-semibold'>Energy histogram</h4>
+                      <h4 class='mt-3 text-sm font-semibold'>Dose/CPS histogram</h4>
                       <div id='${histId}' style='width:384px;height:180px;'></div>
                     </div>`,
                     { maxWidth: 420 }
@@ -260,37 +290,36 @@
                     document.getElementById(`val-${uid}`).textContent = w;
                   };
 
-                  // histogram if energy present
                   const histDiv = document.getElementById(histId);
-                  if (energies.length) {
-                    Plotly.newPlot(
-                      histDiv,
-                      [
-                        {
-                          x: energies,
-                          type: "histogram",
-                          marker: { color: "#f59e0b" },
-                        },
-                      ],
+                  Plotly.newPlot(
+                    histDiv,
+                    [
                       {
-                        margin: { l: 30, r: 20, t: 10, b: 30 },
-                        paper_bgcolor: "#1f2937",
-                        plot_bgcolor: "#1f2937",
-                        font: { color: "#ffffff", size: 10 },
-                        xaxis: { title: "Energy (keV)", showgrid: false },
-                        yaxis: { title: "freq", showgrid: false },
+                        x: dosesArr,
+                        type: "histogram",
+                        opacity: 0.6,
+                        name: "Dose (µSv/h)",
+                        marker: { color: "#38bdf8" },
                       },
-                      { displayModeBar: false }
-                    );
-                  } else {
-                    histDiv.textContent = "No energy data";
-                    histDiv.style.color = "#ffffffaa";
-                    histDiv.style.fontSize = "11px";
-                    histDiv.style.display = "flex";
-                    histDiv.style.alignItems = "center";
-                    histDiv.style.justifyContent = "center";
-                    histDiv.style.height = "180px";
-                  }
+                      {
+                        x: cpsArr,
+                        type: "histogram",
+                        opacity: 0.6,
+                        name: "CPS",
+                        marker: { color: "#f59e0b" },
+                      },
+                    ],
+                    {
+                      barmode: "overlay",
+                      margin: { l: 30, r: 20, t: 10, b: 30 },
+                      paper_bgcolor: "#1f2937",
+                      plot_bgcolor: "#1f2937",
+                      font: { color: "#ffffff", size: 10 },
+                      xaxis: { title: "value", showgrid: false },
+                      yaxis: { title: "freq", showgrid: false },
+                    },
+                    { displayModeBar: false }
+                  );
 
                   // slider
                   drawLine(1);
@@ -308,13 +337,24 @@
 
         /* ------------------ DOT RENDER ------------------ */
         function drawDots() {
+          if (trackView) {
+            pointLayer.clearLayers();
+            return;
+          }
           const metric = document.getElementById("metricSelect").value;
-          const vals = allPoints.map((p) => (metric === "dose" ? p.dose : p.cps));
+          const visiblePoints = allPoints.filter((p) => tracks[p.fname]?.visible);
+          if (!visiblePoints.length) {
+            pointLayer.clearLayers();
+            return;
+          }
+          const vals = visiblePoints.map((p) =>
+            metric === "dose" ? p.dose : p.cps
+          );
           const min = Math.min(...vals);
           const max = Math.max(...vals);
 
           pointLayer.clearLayers();
-          allPoints.forEach((p) => {
+          visiblePoints.forEach((p) => {
             const valMetric = metric === "dose" ? p.dose : p.cps;
             const color = p.dose === 0 && p.cps === 0 ? "#777" : colorScale(valMetric, min, max);
             const marker = L.circleMarker([p.lat, p.lon], {
@@ -335,7 +375,36 @@
           });
         }
 
-        document.getElementById("metricSelect").addEventListener("change", drawDots);
+        document
+          .getElementById("metricSelect")
+          .addEventListener("change", drawDots);
+        trackListElem.addEventListener("change", (e) => {
+          if (!e.target.dataset.file) return;
+          const t = tracks[e.target.dataset.file];
+          t.visible = e.target.checked;
+          if (trackView) {
+            if (t.visible) {
+              lineLayer.addLayer(t.line);
+            } else {
+              lineLayer.removeLayer(t.line);
+            }
+          }
+          drawDots();
+        });
+
+        trackViewToggle.addEventListener("change", () => {
+          trackView = trackViewToggle.checked;
+          if (trackView) {
+            pointLayer.clearLayers();
+            lineLayer.clearLayers();
+            Object.values(tracks).forEach((t) => {
+              if (t.visible) lineLayer.addLayer(t.line);
+            });
+          } else {
+            lineLayer.clearLayers();
+            drawDots();
+          }
+        });
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- lighten text for dark mode readability
- add 'Track view' toggle and hide lines by default
- switch between marker and track line views
- replace energy histogram with dose/cps histogram

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687673b74724832d96ffd585af2296e1