### PR TITLE
Implement fullscreen track popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,23 @@
         </div>
 
       </aside>
+      <!-- Full screen track popup -->
+      <div
+        id="trackPopup"
+        class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden z-[1002] overflow-y-auto p-4 flex items-start justify-center"
+      >
+        <div
+          id="trackPopupContent"
+          class="relative mx-auto w-full max-w-3xl bg-gray-800 rounded-lg p-4 text-gray-200"
+        >
+          <button
+            id="trackPopupClose"
+            class="absolute top-2 right-2 text-gray-300 hover:text-white"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
     </div>
 
     <script>
@@ -111,6 +128,13 @@
         const trackListElem = document.getElementById("trackList");
         const sidebar = document.getElementById("sidebar");
         const trackViewToggle = document.getElementById("trackViewToggle");
+        const trackPopup = document.getElementById("trackPopup");
+        const trackPopupContent = document.getElementById("trackPopupContent");
+        document
+          .getElementById("trackPopupClose")
+          .addEventListener("click", () =>
+            trackPopup.classList.add("hidden")
+          );
         let trackView = false;
 
         document
@@ -223,23 +247,26 @@
               const sliderId = `slider-${uid}`;
 
               line.on("click", () => {
-                line
-                  .bindPopup(
-                    `<div class='prose prose-sm dark:prose-invert text-white'>
-                      <h3 class='text-lg'>${fname.split("/").pop()}</h3>
-                      <p>
-                        <strong>Dose</strong> min ${stats.minDose.toFixed(3)} / avg ${stats.avgDose.toFixed(3)} / max ${stats.maxDose.toFixed(3)} µSv/h<br>
-                        <strong>CPS</strong>  min ${stats.minCps.toFixed(1)} / avg ${stats.avgCps.toFixed(1)} / max ${stats.maxCps.toFixed(1)} cps
-                      </p>
-                      <label class='block text-xs mb-1'>Avg window: <span id='val-${uid}'>1</span></label>
-                      <input type='range' min='1' max='50' value='1' id='${sliderId}' class='w-full mb-2'>
-                      <div id='${plotId}' style='width:384px;height:220px;'></div>
-                      <h4 class='mt-3 text-sm font-semibold'>Dose/CPS histogram</h4>
-                      <div id='${histId}' style='width:384px;height:180px;'></div>
-                    </div>`,
-                    { maxWidth: 420 }
-                  )
-                  .openPopup();
+                trackPopupContent.innerHTML = `
+                  <button id='trackPopupClose' class='absolute top-2 right-2 text-gray-300 hover:text-white'>✕</button>
+                  <div class='prose prose-sm dark:prose-invert text-white'>
+                    <h3 class='text-lg'>${fname.split("/").pop()}</h3>
+                    <p>
+                      <strong>Dose</strong> min ${stats.minDose.toFixed(3)} / avg ${stats.avgDose.toFixed(3)} / max ${stats.maxDose.toFixed(3)} µSv/h<br>
+                      <strong>CPS</strong>  min ${stats.minCps.toFixed(1)} / avg ${stats.avgCps.toFixed(1)} / max ${stats.maxCps.toFixed(1)} cps
+                    </p>
+                    <label class='block text-xs mb-1'>Avg window: <span id='val-${uid}'>1</span></label>
+                    <input type='range' min='1' max='50' value='1' id='${sliderId}' class='w-full mb-2'>
+                    <div id='${plotId}' class='w-full h-56'></div>
+                    <h4 class='mt-3 text-sm font-semibold'>Dose/CPS histogram</h4>
+                    <div id='${histId}' class='w-full h-48'></div>
+                  </div>`;
+                trackPopup.classList.remove("hidden");
+                document
+                  .getElementById("trackPopupClose")
+                  .addEventListener("click", () =>
+                    trackPopup.classList.add("hidden")
+                  );
 
                 setTimeout(() => {
                   const plotDiv = document.getElementById(plotId);


### PR DESCRIPTION
## Summary
- add a fullscreen overlay for track details
- open overlay when clicking a track line with charts inside
- allow closing the overlay via the close button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68767ba83144832daf1703ee1756914d