### PR TITLE
Add SVG icons to homepage tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,10 +19,49 @@
     <main class="max-w-5xl mx-auto p-4">
       <h1 class="text-2xl font-semibold mb-4">Dashboard</h1>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <a href="map.html" class="bg-gray-800 rounded-lg p-8 flex items-center justify-center hover:bg-gray-700">
+        <a
+          href="map.html"
+          class="bg-gray-800 rounded-lg p-8 flex items-center justify-center space-x-2 hover:bg-gray-700"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            class="w-6 h-6"
+          >
+            <path
+              d="M12 21s-6-5.5-6-10a6 6 0 1112 0c0 4.5-6 10-6 10z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+            <circle cx="12" cy="11" r="2" fill="currentColor" stroke="none" />
+          </svg>
           <span class="text-lg font-medium">Radiation Map</span>
         </a>
-        <a href="about.html" class="bg-gray-800 rounded-lg p-8 flex items-center justify-center hover:bg-gray-700">
+        <a
+          href="about.html"
+          class="bg-gray-800 rounded-lg p-8 flex items-center justify-center space-x-2 hover:bg-gray-700"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            class="w-6 h-6"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+            <line x1="12" y1="10" x2="12" y2="16" />
+            <circle cx="12" cy="7" r="1" fill="currentColor" stroke="none" />
+          </svg>
           <span class="text-lg font-medium">About Us</span>
         </a>
       </div>


### PR DESCRIPTION
## Summary
- add inline SVG icons on the dashboard tiles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687680665fa0832dbf156b6f380af25f