### PR TITLE
Improve track popup layout

### DIFF
--- a/map.html
+++ b/map.html
@@ -92,11 +92,11 @@
       <!-- Full screen track popup -->
       <div
         id="trackPopup"
-        class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden z-[1002] flex"
+        class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden z-[1002] flex items-center justify-center p-4"
       >
         <div
           id="trackPopupContent"
-          class="relative w-full h-full bg-gray-800 p-4 text-gray-200 overflow-auto"
+          class="relative bg-gray-800 text-white p-4 overflow-auto max-w-4xl max-h-full w-full rounded-lg"
         >
           <button
             id="trackPopupClose"
@@ -261,17 +261,21 @@
               line.on("click", () => {
                 trackPopupContent.innerHTML = `
                   <button id='trackPopupClose' class='absolute top-2 right-2 text-gray-300 hover:text-white'>✕</button>
-                  <div class='prose prose-sm dark:prose-invert text-white'>
-                    <h3 class='text-lg'>${fname.split("/").pop()}</h3>
-                    <p>
-                      <strong>Dose</strong> min ${stats.minDose.toFixed(3)} / avg ${stats.avgDose.toFixed(3)} / max ${stats.maxDose.toFixed(3)} µSv/h<br>
-                      <strong>CPS</strong>  min ${stats.minCps.toFixed(1)} / avg ${stats.avgCps.toFixed(1)} / max ${stats.maxCps.toFixed(1)} cps
-                    </p>
-                    <label class='block text-xs mb-1'>Avg window: <span id='val-${uid}'>1</span></label>
-                    <input type='range' min='1' max='50' value='1' id='${sliderId}' class='w-full mb-2'>
-                    <div id='${plotId}' class='w-full h-72'></div>
-                    <h4 class='mt-3 text-sm font-semibold'>Dose/CPS histogram</h4>
-                    <div id='${histId}' class='w-full h-64'></div>
+                  <div class='grid md:grid-cols-2 gap-4 text-white'>
+                    <div>
+                      <h3 class='text-lg font-semibold mb-2'>${fname.split("/").pop()}</h3>
+                      <p class='mb-2'>
+                        <strong>Dose</strong> min ${stats.minDose.toFixed(3)} / avg ${stats.avgDose.toFixed(3)} / max ${stats.maxDose.toFixed(3)} µSv/h<br>
+                        <strong>CPS</strong>  min ${stats.minCps.toFixed(1)} / avg ${stats.avgCps.toFixed(1)} / max ${stats.maxCps.toFixed(1)} cps
+                      </p>
+                      <label class='block text-xs mb-1'>Avg window: <span id='val-${uid}'>1</span></label>
+                      <input type='range' min='1' max='50' value='1' id='${sliderId}' class='w-full mb-2'>
+                      <div id='${plotId}' class='w-full h-72'></div>
+                    </div>
+                    <div>
+                      <h4 class='text-sm font-semibold mb-2'>Dose/CPS histogram</h4>
+                      <div id='${histId}' class='w-full h-72'></div>
+                    </div>
                   </div>`;
                 trackPopup.classList.remove("hidden");
                 document


### PR DESCRIPTION
## Summary
- center and enlarge the full-screen track popup
- redesign popup contents using a two-column layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876869e4ca8832d92239d023e6e0226