### PR TITLE
Sort track points by timestamp

### DIFF
--- a/map.html
+++ b/map.html
@@ -239,6 +239,7 @@
                   dose: +(m.doseRate ?? m.dose_uSv_h ?? m.dose ?? 0),
                   cps: +(m.countRate ?? m.cps ?? 0),
                   energy: +(m.energy ?? m.energyValue ?? m.energy_ev ?? NaN),
+                  date: +m.date || 0,
                 }))
                 .filter((p) => !isNaN(p.lat) && !isNaN(p.lon));
             }
@@ -256,6 +257,7 @@
               dose: +r[2],
               cps: +r[3],
               energy: +r[4] || NaN,
+              date: 0,
             }))
             .filter((p) => !isNaN(p.lat) && !isNaN(p.lon));
         };
@@ -286,8 +288,9 @@
                 allPoints.push(p);
               });
 
-              // line: connect sequentially (no closing) – original method
-              const path = pts.map((p) => [p.lat, p.lon]);
+              // line: connect points in chronological order
+              const sorted = [...pts].sort((a, b) => a.date - b.date);
+              const path = sorted.map((p) => [p.lat, p.lon]);
               const line = L.polyline(path, {
                 color: "#facc15",
                 weight: 3,


### PR DESCRIPTION
## Summary
- parse `.rctrk` markers with their `date`
- ensure polyline points are ordered chronologically

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68768b8a41b8832da9bbeca8dfc996f9