### PR TITLE
Display timestamp and energy in map popups

### DIFF
--- a/map.html
+++ b/map.html
@@ -612,12 +612,20 @@
               weight: 0,
             }).addTo(pointLayer);
 
-            marker.bindPopup(
+            const dateStr =
+              p.date && !isNaN(p.date)
+                ? new Date(p.date * 1000).toLocaleString()
+                : "N/A";
+            let popupHtml =
               `<div class='prose prose-sm prose-invert'>` +
-                `<strong>Dose:</strong> ${p.dose.toFixed(3)} µSv/h<br>` +
-                `<strong>CPS:</strong> ${p.cps.toFixed(1)} cps` +
-                `</div>`
-            );
+              `<strong>Date:</strong> ${dateStr}<br>` +
+              `<strong>Dose:</strong> ${p.dose.toFixed(3)} µSv/h<br>` +
+              `<strong>CPS:</strong> ${p.cps.toFixed(1)} cps`;
+            if (Number.isFinite(p.energy) && p.energy > 0) {
+              popupHtml += `<br><strong>Energy:</strong> ${p.energy.toFixed(1)} keV`;
+            }
+            popupHtml += `</div>`;
+            marker.bindPopup(popupHtml);
           });
         }
 


### PR DESCRIPTION
## Summary
- enhance marker popups to show a human readable timestamp
- include energy information when available

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876b63fd7f4832d9d69e3742f27f1a0