### PR TITLE
Handle incorrect time range on map

### DIFF
--- a/map.html
+++ b/map.html
@@ -336,6 +336,18 @@
           );
         };
 
+        const checkTimes = () => {
+          const start = startTimeInput.valueAsNumber;
+          const end = endTimeInput.valueAsNumber;
+          if (!isNaN(start) && !isNaN(end) && start > end) {
+            const tmp = startTimeInput.value;
+            startTimeInput.value = endTimeInput.value;
+            endTimeInput.value = tmp;
+            return true;
+          }
+          return false;
+        };
+
         const computeStats = (pts) => {
           if (!pts.length)
             return {
@@ -752,8 +764,14 @@
           drawDots();
         });
 
-        startTimeInput.addEventListener("change", drawDots);
-        endTimeInput.addEventListener("change", drawDots);
+        startTimeInput.addEventListener("change", () => {
+          checkTimes();
+          drawDots();
+        });
+        endTimeInput.addEventListener("change", () => {
+          checkTimes();
+          drawDots();
+        });
 
         trackViewToggle.addEventListener("change", () => {
           trackView = trackViewToggle.checked;


### PR DESCRIPTION
## Summary
- detect when the selected start time is after the end time
- automatically swap the start and end time values
- redraw dots after adjusting the input values

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6876bc060b64832da84616a4fe51da64