### PR TITLE
Fix track popups plots

### DIFF
--- a/map.html
+++ b/map.html
@@ -419,6 +419,9 @@
               const sliderDoseId = `slider-dose-${uid}`;
 
               line.on("click", () => {
+                let filtered = filterByDate(pts);
+                if (!filtered.length) filtered = pts;
+                const stats = computeStats(filtered);
 
                 const displayName = tracks[fname].title || fname.split("/").pop();
 
@@ -546,7 +549,7 @@
                           x,
                           y: vals,
                           name: "CPS",
-                          type: "scatter",
+                          type: "scattergl",
                           mode: "lines",
                           line: {
                             width: 2,
@@ -586,7 +589,7 @@
                           x,
                           y: vals,
                           name: "Dose (µSv/h)",
-                          type: "scatter",
+                          type: "scattergl",
                           mode: "lines",
                           line: {
                             width: 2,

--- a/map.js
+++ b/map.js
@@ -240,7 +240,8 @@ window.addEventListener("load", () => {
         const sliderDoseId = `slider-dose-${uid}`;
 
         line.on("click", () => {
-          const filtered = filterByDate(pts);
+          let filtered = filterByDate(pts);
+          if (!filtered.length) filtered = pts;
           const stats = computeStats(filtered);
           trackPopupContent.innerHTML = `
             <button id='trackPopupClose' class='absolute top-2 right-2 text-gray-300 hover:text-white'>✕</button>
@@ -366,7 +367,7 @@ window.addEventListener("load", () => {
                     x,
                     y: vals,
                     name: "CPS",
-                    type: "scatter",
+                    type: "scattergl",
                     mode: "lines",
                     line: {
                       width: 2,
@@ -406,7 +407,7 @@ window.addEventListener("load", () => {
                     x,
                     y: vals,
                     name: "Dose (µSv/h)",
-                    type: "scatter",
+                    type: "scattergl",
                     mode: "lines",
                     line: {
                       width: 2,


### PR DESCRIPTION
## Summary
- ensure track stats fall back to all points when date filter hides everything
- use scattergl for gradient lines in track plots

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876beb7bcc0832d9cfe8d3384f173e9