### PR TITLE
Fix gradient lines in track plots

### DIFF
--- a/map.html
+++ b/map.html
@@ -549,7 +549,7 @@
                           x,
                           y: vals,
                           name: "CPS",
-                          type: "scattergl",
+                          type: "scatter",
                           mode: "lines",
                           line: {
                             width: 2,
@@ -589,7 +589,7 @@
                           x,
                           y: vals,
                           name: "Dose (µSv/h)",
-                          type: "scattergl",
+                          type: "scatter",
                           mode: "lines",
                           line: {
                             width: 2,

--- a/map.js
+++ b/map.js
@@ -367,7 +367,7 @@ window.addEventListener("load", () => {
                     x,
                     y: vals,
                     name: "CPS",
-                    type: "scattergl",
+                    type: "scatter",
                     mode: "lines",
                     line: {
                       width: 2,
@@ -407,7 +407,7 @@ window.addEventListener("load", () => {
                     x,
                     y: vals,
                     name: "Dose (µSv/h)",
-                    type: "scattergl",
+                    type: "scatter",
                     mode: "lines",
                     line: {
                       width: 2,


### PR DESCRIPTION
## Summary
- fix track popup plots by using `scatter` instead of `scattergl`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876c1b3ce40832dae2a490730501230