### PR TITLE
Handle zero-value readings in stats

### DIFF
--- a/map.html
+++ b/map.html
@@ -347,18 +347,19 @@
           return false;
         };
 
-        const computeStats = (pts) => {
-          if (!pts.length)
-            return {
-              avgDose: 0,
-              minDose: 0,
-              maxDose: 0,
-              avgCps: 0,
-              minCps: 0,
-              maxCps: 0,
-            };
-          const doses = pts.map((p) => p.dose);
-          const cpses = pts.map((p) => p.cps);
+          const computeStats = (pts) => {
+            const filtered = pts.filter((p) => p.dose !== 0 || p.cps !== 0);
+            if (!filtered.length)
+              return {
+                avgDose: 0,
+                minDose: 0,
+                maxDose: 0,
+                avgCps: 0,
+                minCps: 0,
+                maxCps: 0,
+              };
+            const doses = filtered.map((p) => p.dose);
+            const cpses = filtered.map((p) => p.cps);
           return {
             avgDose: doses.reduce((a, b) => a + b, 0) / doses.length,
             minDose: Math.min(...doses),
@@ -705,11 +706,15 @@
             legend.classList.add("hidden");
             return;
           }
-          const vals = visiblePoints.map((p) =>
-            metric === "dose" ? p.dose : p.cps
-          );
-          const min = Math.min(...vals);
-          const max = Math.max(...vals);
+            const filteredVals = visiblePoints.filter(
+              (p) => p.dose !== 0 || p.cps !== 0
+            );
+            const sample = filteredVals.length ? filteredVals : visiblePoints;
+            const vals = sample.map((p) =>
+              metric === "dose" ? p.dose : p.cps
+            );
+            const min = Math.min(...vals);
+            const max = Math.max(...vals);
 
           const legendLabel = document.getElementById("legend-label");
           const legendBar = document.getElementById("legend-bar");

--- a/map.js
+++ b/map.js
@@ -170,7 +170,8 @@ window.addEventListener("load", () => {
   };
 
   const computeStats = (pts) => {
-    if (!pts.length)
+    const filtered = pts.filter((p) => p.dose !== 0 || p.cps !== 0);
+    if (!filtered.length)
       return {
         avgDose: 0,
         minDose: 0,
@@ -179,8 +180,8 @@ window.addEventListener("load", () => {
         minCps: 0,
         maxCps: 0,
       };
-    const doses = pts.map((p) => p.dose);
-    const cpses = pts.map((p) => p.cps);
+    const doses = filtered.map((p) => p.dose);
+    const cpses = filtered.map((p) => p.cps);
     return {
       avgDose: doses.reduce((a, b) => a + b, 0) / doses.length,
       minDose: Math.min(...doses),
@@ -519,9 +520,11 @@ window.addEventListener("load", () => {
       legend.classList.add("hidden");
       return;
     }
-    const vals = visiblePoints.map((p) =>
-      metric === "dose" ? p.dose : p.cps
+    const filteredVals = visiblePoints.filter(
+      (p) => p.dose !== 0 || p.cps !== 0
     );
+    const sample = filteredVals.length ? filteredVals : visiblePoints;
+    const vals = sample.map((p) => (metric === "dose" ? p.dose : p.cps));
     const min = Math.min(...vals);
     const max = Math.max(...vals);
 


### PR DESCRIPTION
## Summary
- ignore points that have both zero dose and CPS when calculating statistics
- compute legend min/max from non-zero values

## Testing
- `node --check map.js`


------
https://chatgpt.com/codex/tasks/task_e_6876c23abe54832d88a2e0b86512e64b