### PR TITLE
Improve track view visuals and adaptive colors

### DIFF
--- a/map.html
+++ b/map.html
@@ -115,8 +115,10 @@
           </select>
         </div>
         <div>
-          <label class="flex items-center gap-2 text-gray-200" for="trackViewToggle">
-            <input type="checkbox" id="trackViewToggle" class="accent-blue-500" /> Track view
+          <label class="flex items-center gap-2 text-gray-200 cursor-pointer" for="trackViewToggle">
+            <input type="checkbox" id="trackViewToggle" class="sr-only peer" />
+            <div class="w-11 h-6 bg-gray-600 rounded-full peer-checked:bg-blue-600 relative after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full"></div>
+            <span>Track view</span>
           </label>
         </div>
         <div>
@@ -199,11 +201,14 @@
           ),
         };
         let currentBase = baseLayers.dark.addTo(map);
+        let baseIsDark = true;
         document.getElementById("basemapSelect").addEventListener("change", (e) => {
           const key = e.target.value;
           if (baseLayers[key]) {
             map.removeLayer(currentBase);
             currentBase = baseLayers[key].addTo(map);
+            baseIsDark = key === "dark";
+            updateTrackColors();
           }
         });
         L.control.zoom({ position: "bottomleft" }).addTo(map);
@@ -224,6 +229,16 @@
         /* ------------------ STATE ------------------ */
         const allPoints = [];
         const tracks = {};
+        let nextHue = 0;
+        const trackLightnessDark = 60;
+        const trackLightnessLight = 40;
+        const trackColorForHue = (h) =>
+          `hsl(${h}, 100%, ${baseIsDark ? trackLightnessDark : trackLightnessLight}%)`;
+        const nextTrackHue = () => {
+          const h = nextHue;
+          nextHue = (nextHue + 137.508) % 360;
+          return h;
+        };
         const pointLayer = L.layerGroup().addTo(map);
         const lineLayer = L.layerGroup().addTo(map);
         const trackListElem = document.getElementById("trackList");
@@ -347,8 +362,8 @@
           return false;
         };
 
-          const computeStats = (pts) => {
-            const filtered = pts.filter((p) => p.dose !== 0 || p.cps !== 0);
+        const computeStats = (pts) => {
+          const filtered = pts.filter((p) => p.dose !== 0 || p.cps !== 0);
             if (!filtered.length)
               return {
                 avgDose: 0,
@@ -366,8 +381,16 @@
             maxDose: Math.max(...doses),
             avgCps: cpses.reduce((a, b) => a + b, 0) / cpses.length,
             minCps: Math.min(...cpses),
-            maxCps: Math.max(...cpses),
-          };
+          maxCps: Math.max(...cpses),
+        };
+      };
+
+        const updateTrackColors = () => {
+          Object.values(tracks).forEach((t) => {
+            const color = trackColorForHue(t.hue);
+            t.line.setStyle({ color });
+            if (t.swatch) t.swatch.style.background = color;
+          });
         };
 
         /* ------------------ MAIN LOAD ------------------ */
@@ -395,18 +418,32 @@
 
               // line: connect points in chronological order
               const path = pts.map((p) => [p.lat, p.lon]);
+              const hue = nextTrackHue();
+              const color = trackColorForHue(hue);
               const line = L.polyline(path, {
-                color: "#facc15",
+                color,
                 weight: 3,
                 opacity: 0.7,
               });
-              tracks[fname] = { points: pts, line, visible: true, title };
               const li = document.createElement("li");
               const label = title || fname.split("/").pop();
-              li.innerHTML =
-                `<label class='flex items-center gap-2 text-gray-200'><input type='checkbox' class='trackCheck accent-blue-500' data-file='${fname}' checked> ${label}</label>`;
-
+              const checkbox = document.createElement("input");
+              checkbox.type = "checkbox";
+              checkbox.className = "trackCheck accent-blue-500";
+              checkbox.dataset.file = fname;
+              checkbox.checked = true;
+              const swatch = document.createElement("span");
+              swatch.className = "inline-block w-3 h-3 rounded-full";
+              swatch.style.background = color;
+              const labelElem = document.createElement("label");
+              labelElem.className = "flex items-center gap-2 text-gray-200";
+              labelElem.appendChild(checkbox);
+              labelElem.appendChild(swatch);
+              labelElem.appendChild(document.createTextNode(" " + label));
+              li.appendChild(labelElem);
               trackListElem.appendChild(li);
+
+              tracks[fname] = { points: pts, line, visible: true, title, hue, swatch };
 
 
 


### PR DESCRIPTION
## Summary
- restyle the track view toggle with a modern switch control
- adapt track line colors based on map background for better contrast
- update track listings to store color metadata
- synchronize inline and external scripts for new behavior

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876c4f19044832db133495110e48c5e