### PR TITLE
Fix sidebar offset & menu z-index

### DIFF
--- a/map.html
+++ b/map.html
@@ -86,7 +86,7 @@
       <div id="map" class="flex-1"></div>
       <aside
         id="sidebar"
-        class="fixed top-14 left-0 h-full w-72 max-w-full bg-gray-800/90 backdrop-blur-md p-4 space-y-4 overflow-y-auto transform -translate-x-full transition-transform z-[1000] md:relative md:translate-x-0 md:w-72 md:bg-opacity-100 text-gray-200"
+        class="fixed top-14 md:top-0 left-0 h-full w-72 max-w-full bg-gray-800/90 backdrop-blur-md p-4 space-y-4 overflow-y-auto transform -translate-x-full transition-transform z-[1000] md:relative md:translate-x-0 md:w-72 md:bg-opacity-100 text-gray-200"
 
       >
         <h2 class="text-lg font-semibold mb-2">Tracks</h2>

--- a/nav.html
+++ b/nav.html
@@ -1,4 +1,4 @@
-<nav class="bg-gray-800 text-gray-100 fixed top-0 left-0 right-0 z-50">
+<nav class="bg-gray-800 text-gray-100 fixed top-0 left-0 right-0 z-[1100]">
   <div class="max-w-5xl mx-auto px-4 py-3 flex justify-between items-center">
     <a href="index.html" class="font-bold">OCDE</a>
     <div class="space-x-4">


### PR DESCRIPTION
## Summary
- keep menu bar above all content
- align sidebar with the map on desktop

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876c69c5e80832d99d6c0e674f08700