### PR TITLE
Fix gradient plots using scatter

### DIFF
--- a/map.html
+++ b/map.html
@@ -543,7 +543,7 @@
 
                   const drawCps = (w) => {
                     const vals = movingAvg(cpsArr, w);
-                    Plotly.react(
+                    Plotly.newPlot(
                       plotCpsDiv,
                       [
                         {
@@ -583,7 +583,7 @@
 
                   const drawDose = (w) => {
                     const vals = movingAvg(dosesArr, w);
-                    Plotly.react(
+                    Plotly.newPlot(
                       plotDoseDiv,
                       [
                         {

--- a/map.js
+++ b/map.js
@@ -368,7 +368,7 @@ window.addEventListener("load", () => {
 
             const drawCps = (w) => {
               const vals = movingAvg(cpsArr, w);
-              Plotly.react(
+              Plotly.newPlot(
                 plotCpsDiv,
                 [
                   {
@@ -408,7 +408,7 @@ window.addEventListener("load", () => {
 
             const drawDose = (w) => {
               const vals = movingAvg(dosesArr, w);
-              Plotly.react(
+              Plotly.newPlot(
                 plotDoseDiv,
                 [
                   {


### PR DESCRIPTION
## Summary
- revert track popup to use `scatter` for gradient plots
- use `Plotly.newPlot` to reliably render CPS and dose charts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876c471dda4832db571c5c810b1790a