### PR TITLE
Add opacity and marker controls

### DIFF
--- a/map.html
+++ b/map.html
@@ -167,9 +167,7 @@
               </select>
             </div>
             <div>
-              <label for="lineWidthInput" class="block mb-1 font-medium"
-                >Width</label
-              >
+              <label for="lineWidthInput" class="block mb-1 font-medium">Width</label>
               <input
                 type="number"
                 id="lineWidthInput"
@@ -179,15 +177,46 @@
                 class="bg-gray-700 border border-gray-600 rounded-md px-2 py-1 w-full focus:outline-none"
               />
             </div>
-            <label class="flex items-center gap-2 text-gray-200">
+            <div>
+              <label for="lineOpacityInput" class="block mb-1 font-medium">Line opacity</label>
               <input
-                type="checkbox"
-                id="lineShadowToggle"
-                class="accent-blue-500"
-                checked
+                type="range"
+                id="lineOpacityInput"
+                min="0"
+                max="1"
+                step="0.1"
+                value="0.7"
+                class="w-full accent-blue-500"
               />
-              <span>Shadow</span>
+            </div>
+            <div>
+              <label for="lineShadowSlider" class="block mb-1 font-medium">Shadow</label>
+              <input
+                type="range"
+                id="lineShadowSlider"
+                min="0"
+                max="10"
+                step="0.5"
+                value="2"
+                class="w-full accent-blue-500"
+              />
+            </div>
+            <label class="flex items-center gap-2 text-gray-200">
+              <input type="checkbox" id="showTrackDotsToggle" class="accent-blue-500" />
+              <span>Show markers</span>
             </label>
+            <div>
+              <label for="dotOpacitySlider" class="block mb-1 font-medium">Dot opacity</label>
+              <input
+                type="range"
+                id="dotOpacitySlider"
+                min="0"
+                max="1"
+                step="0.1"
+                value="0.5"
+                class="w-full accent-blue-500"
+              />
+            </div>
           </div>
         </div>
         <div id="errorMessage" class="text-red-400 text-sm hidden"></div>
@@ -299,6 +328,7 @@
         };
         const pointLayer = L.layerGroup().addTo(map);
         const lineLayer = L.layerGroup().addTo(map);
+        const trackDotLayer = L.layerGroup();
         const trackListElem = document.getElementById("trackList");
         const sidebar = document.getElementById("sidebar");
         const trackViewToggle = document.getElementById("trackViewToggle");
@@ -308,7 +338,10 @@
         const lineStylePanel = document.getElementById("lineStylePanel");
         const lineStyleSelect = document.getElementById("lineStyleSelect");
         const lineWidthInput = document.getElementById("lineWidthInput");
-        const lineShadowToggle = document.getElementById("lineShadowToggle");
+        const lineOpacityInput = document.getElementById("lineOpacityInput");
+        const lineShadowSlider = document.getElementById("lineShadowSlider");
+        const showTrackDotsToggle = document.getElementById("showTrackDotsToggle");
+        const dotOpacitySlider = document.getElementById("dotOpacitySlider");
         const errorMessage = document.getElementById("errorMessage");
         const trackPopup = document.getElementById("trackPopup");
         const trackPopupContent = document.getElementById("trackPopupContent");
@@ -322,7 +355,10 @@
         let globalMaxDate = -Infinity;
         let lineDash = null;
         let lineWidth = 3;
-        let lineShadow = true;
+        let lineOpacity = 0.7;
+        let lineShadow = 2;
+        let showTrackDots = false;
+        let dotOpacity = 0.5;
 
         document
           .getElementById("toggleSidebar")
@@ -498,16 +534,58 @@
             const color = trackColorForHue(t.hue);
             t.line.setStyle({ color });
             if (t.swatch) t.swatch.style.background = color;
+            if (t.markerGroup) {
+              t.markerGroup.eachLayer((m) =>
+                m.setStyle({ color, fillColor: color })
+              );
+            }
+          });
+        };
+
+        const renderTrackDots = () => {
+          trackDotLayer.clearLayers();
+          if (!(trackView && showTrackDots)) return;
+          trackDotLayer.addTo(map);
+          Object.values(tracks).forEach((t) => {
+            if (!t.visible) return;
+            if (!t.markerGroup) {
+              const color = trackColorForHue(t.hue);
+              const g = L.layerGroup();
+              t.points.forEach((p) => {
+                const m = L.circleMarker([p.lat, p.lon], {
+                  radius: 3,
+                  color,
+                  fillColor: color,
+                  weight: 1,
+                  opacity: dotOpacity,
+                  fillOpacity: dotOpacity,
+                  className: "track-marker",
+                });
+                g.addLayer(m);
+              });
+              t.markerGroup = g;
+            }
+            t.markerGroup.eachLayer((m) =>
+              m.setStyle({ opacity: dotOpacity, fillOpacity: dotOpacity })
+            );
+            trackDotLayer.addLayer(t.markerGroup);
           });
         };
 
         const updateLineStyles = () => {
           Object.values(tracks).forEach((t) => {
-            t.line.setStyle({ weight: lineWidth, dashArray: lineDash });
+            t.line.setStyle({
+              weight: lineWidth,
+              dashArray: lineDash,
+              opacity: lineOpacity,
+            });
+            if (t.markerGroup) {
+              t.markerGroup.eachLayer((m) =>
+                m.setStyle({ opacity: dotOpacity, fillOpacity: dotOpacity })
+              );
+            }
           });
-          styleElem.textContent = `.track-line, .data-dot { filter: ${
-            lineShadow ? "drop-shadow(0 0 2px #000)" : "none"
-          }; }`;
+          styleElem.textContent = `.track-line, .data-dot { filter: drop-shadow(0 0 ${lineShadow}px #000); }`;
         };
 
         /* ------------------ MAIN LOAD ------------------ */
@@ -562,7 +640,7 @@
               li.appendChild(labelElem);
               trackListElem.appendChild(li);
 
-              tracks[fname] = { points: pts, line, visible: true, title, hue, swatch };
+              tracks[fname] = { points: pts, line, visible: true, title, hue, swatch, markerGroup: null };
 
 
 
@@ -931,8 +1009,13 @@
           if (trackView) {
             if (t.visible) {
               lineLayer.addLayer(t.line);
+              if (showTrackDots) {
+                if (!t.markerGroup) renderTrackDots();
+                else trackDotLayer.addLayer(t.markerGroup);
+              }
             } else {
               lineLayer.removeLayer(t.line);
+              if (t.markerGroup) trackDotLayer.removeLayer(t.markerGroup);
             }
           }
           drawDots();
@@ -952,12 +1035,15 @@
           if (trackView) {
             pointLayer.clearLayers();
             lineLayer.clearLayers();
+            trackDotLayer.clearLayers();
             Object.values(tracks).forEach((t) => {
               if (t.visible) lineLayer.addLayer(t.line);
             });
             updateLineStyles();
+            renderTrackDots();
           } else {
             lineLayer.clearLayers();
+            trackDotLayer.clearLayers();
             drawDots();
           }
 
@@ -977,9 +1063,30 @@
             updateLineStyles();
           }
         });
-        lineShadowToggle.addEventListener("change", (e) => {
-          lineShadow = e.target.checked;
-          updateLineStyles();
+        lineOpacityInput.addEventListener("input", (e) => {
+          const v = parseFloat(e.target.value);
+          if (!isNaN(v)) {
+            lineOpacity = v;
+            updateLineStyles();
+          }
+        });
+        lineShadowSlider.addEventListener("input", (e) => {
+          const v = parseFloat(e.target.value);
+          if (!isNaN(v)) {
+            lineShadow = v;
+            updateLineStyles();
+          }
+        });
+        dotOpacitySlider.addEventListener("input", (e) => {
+          const v = parseFloat(e.target.value);
+          if (!isNaN(v)) {
+            dotOpacity = v;
+            updateLineStyles();
+          }
+        });
+        showTrackDotsToggle.addEventListener("change", (e) => {
+          showTrackDots = e.target.checked;
+          renderTrackDots();
         });
       });
     </script>


### PR DESCRIPTION
## Summary
- tweak line style panel with more controls
- support line and dot opacity and dynamic shadows
- allow showing track markers in track view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687776756868832d9f0dec3919549309