### PR TITLE
Add Site markers and editor page

### DIFF
--- a/data/sites.json
+++ b/data/sites.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "Sample Site",
+    "lat": 44.3209,
+    "lon": 7.6094,
+    "description": "Example location",
+    "images": ["https://placehold.co/300x200"]
+  }
+]

--- a/map.html
+++ b/map.html
@@ -379,6 +379,8 @@
         const pointLayer = L.layerGroup().addTo(map);
         const lineLayer = L.layerGroup().addTo(map);
         const trackDotLayer = L.layerGroup();
+        const siteLayer = L.layerGroup().addTo(map);
+        const sites = [];
         const trackListElem = document.getElementById("trackList");
         const sidebar = document.getElementById("sidebar");
         const trackViewToggle = document.getElementById("trackViewToggle");
@@ -478,6 +480,30 @@
             g = Math.round(255 * (1 - (t - 0.5) * 2)); // yellow -> red
           }
           return `rgb(${r},${g},0)`;
+        };
+
+        const loadSites = async () => {
+          try {
+            const res = await fetch("data/sites.json");
+            if (!res.ok) return;
+            const data = await res.json();
+            data.forEach((s) => {
+              const m = L.marker([s.lat, s.lon]).addTo(siteLayer);
+              let html = `<div class='prose prose-sm prose-invert'>`;
+              html += `<h3 class='font-semibold mb-2'>${s.name}</h3>`;
+              if (Array.isArray(s.images)) {
+                html += s.images
+                  .map((u) => `<img src='${u}' class='mb-2 rounded-lg'>`)
+                  .join("");
+              }
+              if (s.description) html += `<p>${s.description}</p>`;
+              html += `</div>`;
+              m.bindPopup(html);
+              sites.push({ ...s, marker: m });
+            });
+          } catch {
+            console.warn("sites data missing");
+          }
         };
 
         const animateCounter = (el, value, decimals = 0) => {
@@ -956,6 +982,8 @@
             }
           }
 
+          await loadSites();
+          sites.forEach((s) => bounds.push([s.lat, s.lon]));
           if (bounds.length) map.fitBounds(bounds, { padding: [50, 50] });
           if (globalMinDate !== Infinity) {
             startTimeInput.valueAsNumber = globalMinDate * 1000;

--- a/nav.html
+++ b/nav.html
@@ -3,6 +3,7 @@
     <a href="index.html" class="font-bold">OCDE</a>
     <div class="space-x-4">
       <a href="map.html" class="hover:underline">Map</a>
+      <a href="site_tool.html" class="hover:underline">Site Tool</a>
       <a href="about.html" class="hover:underline">About Us</a>
     </div>
   </div>

--- a/site_tool.html
+++ b/site_tool.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Site Tool</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography" defer></script>
+  </head>
+  <body class="bg-gray-900 text-gray-200 pt-14">
+    <div id="nav-placeholder"></div>
+    <main class="max-w-3xl mx-auto p-4 space-y-6">
+      <h1 class="text-2xl font-semibold">Site Manager</h1>
+      <form id="siteForm" class="space-y-2">
+        <input required id="name" placeholder="Name" class="w-full p-2 rounded bg-gray-800" />
+        <div class="flex gap-2">
+          <input required id="lat" type="number" step="any" placeholder="Lat" class="flex-1 p-2 rounded bg-gray-800" />
+          <input required id="lon" type="number" step="any" placeholder="Lon" class="flex-1 p-2 rounded bg-gray-800" />
+        </div>
+        <textarea id="description" placeholder="Description" class="w-full p-2 rounded bg-gray-800"></textarea>
+        <input id="image" placeholder="Image URL" class="w-full p-2 rounded bg-gray-800" />
+        <button type="submit" class="bg-blue-600 px-4 py-2 rounded">Add</button>
+      </form>
+      <div>
+        <h2 class="text-xl font-semibold mt-4">Current Sites</h2>
+        <ul id="siteList" class="space-y-1 mt-2 text-sm"></ul>
+      </div>
+      <div>
+        <h2 class="text-xl font-semibold mt-4">JSON Output</h2>
+        <textarea id="output" class="w-full h-40 bg-gray-800 p-2 rounded" readonly></textarea>
+      </div>
+    </main>
+    <script>
+      fetch('nav.html').then(r => r.text()).then(html => {
+        document.getElementById('nav-placeholder').outerHTML = html;
+      });
+      const sites = [];
+      const list = document.getElementById('siteList');
+      const output = document.getElementById('output');
+      function renderOutput(){
+        output.value = JSON.stringify(sites, null, 2);
+      }
+      function addSite(site){
+        sites.push(site);
+        const li = document.createElement('li');
+        li.textContent = `${site.name} (${site.lat.toFixed(5)}, ${site.lon.toFixed(5)})`;
+        list.appendChild(li);
+      }
+      fetch('data/sites.json').then(r => r.json()).then(data => {
+        data.forEach(addSite);
+        renderOutput();
+      }).catch(()=>{});
+      document.getElementById('siteForm').addEventListener('submit', e => {
+        e.preventDefault();
+        const site = {
+          name: document.getElementById('name').value.trim(),
+          lat: parseFloat(document.getElementById('lat').value),
+          lon: parseFloat(document.getElementById('lon').value),
+          description: document.getElementById('description').value.trim(),
+          images: document.getElementById('image').value.trim() ? [document.getElementById('image').value.trim()] : []
+        };
+        addSite(site);
+        e.target.reset();
+        renderOutput();
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- support site markers loaded from `data/sites.json`
- add simple HTML tool to create site entries
- link to the tool from navigation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68777c853650832da3f57c4782d6563a