### PR TITLE
Add site editor and display markers

### DIFF
--- a/data/sites.json
+++ b/data/sites.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "site1",
+    "title": "Site Name",
+    "lat": 44.5,
+    "lon": 7.5,
+    "description": "Short text",
+    "images": ["img/site1.jpg"]
+  }
+]

--- a/map.html
+++ b/map.html
@@ -379,6 +379,7 @@
         const pointLayer = L.layerGroup().addTo(map);
         const lineLayer = L.layerGroup().addTo(map);
         const trackDotLayer = L.layerGroup();
+        const siteLayer = L.layerGroup().addTo(map);
         const trackListElem = document.getElementById("trackList");
         const sidebar = document.getElementById("sidebar");
         const trackViewToggle = document.getElementById("trackViewToggle");
@@ -639,6 +640,31 @@
             }
           });
           styleElem.textContent = `.track-line, .data-dot { filter: drop-shadow(0 0 ${lineShadow}px #000); }`;
+        };
+
+        const fetchSites = async () => {
+          try {
+            const res = await fetch("data/sites.json");
+            if (!res.ok) throw new Error();
+            return await res.json();
+          } catch {
+            console.warn("sites.json missing");
+            return [];
+          }
+        };
+
+        const loadSites = async () => {
+          const sites = await fetchSites();
+          sites.forEach((s) => {
+            if (isNaN(s.lat) || isNaN(s.lon)) return;
+            const m = L.marker([s.lat, s.lon]).addTo(siteLayer);
+            let html = `<h3 class='font-semibold mb-1'>${s.title ?? ""}</h3>`;
+            if (s.description) html += `<p>${s.description}</p>`;
+            if (Array.isArray(s.images) && s.images[0]) {
+              html += `<img src='${s.images[0]}' class='mt-2 rounded w-32 h-auto'/>`;
+            }
+            m.bindPopup(html);
+          });
         };
 
         /* ------------------ MAIN LOAD ------------------ */
@@ -962,6 +988,7 @@
             endTimeInput.valueAsNumber = globalMaxDate * 1000;
           }
           drawDots();
+          loadSites();
         })();
 
         /* ------------------ DOT RENDER ------------------ */

--- a/nav.html
+++ b/nav.html
@@ -10,6 +10,9 @@
     </a>
     <div class="space-x-6 text-sm font-medium">
       <a href="map.html" class="hover:text-gray-200 transition-colors">Map</a>
+      <a href="site-editor.html" class="hover:text-gray-200 transition-colors"
+        >Edit Sites</a
+      >
       <a href="about.html" class="hover:text-gray-200 transition-colors"
         >About Us</a
       >

--- a/site-editor.html
+++ b/site-editor.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Site Editor</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography" defer></script>
+  </head>
+  <body class="bg-gray-900 text-gray-200 pt-14">
+    <div id="nav-placeholder"></div>
+    <main class="max-w-3xl mx-auto p-4 space-y-6">
+      <h1 class="text-xl font-semibold mb-4">Edit Sites</h1>
+      <form id="siteForm" class="space-y-4 bg-gray-800 p-4 rounded">
+        <div>
+          <label for="siteId" class="block mb-1">ID</label>
+          <input id="siteId" name="siteId" required class="w-full bg-gray-700 rounded px-2 py-1" />
+        </div>
+        <div>
+          <label for="title" class="block mb-1">Title</label>
+          <input id="title" name="title" required class="w-full bg-gray-700 rounded px-2 py-1" />
+        </div>
+        <div class="grid grid-cols-2 gap-2">
+          <div>
+            <label for="lat" class="block mb-1">Latitude</label>
+            <input id="lat" name="lat" type="number" step="any" required class="w-full bg-gray-700 rounded px-2 py-1" />
+          </div>
+          <div>
+            <label for="lon" class="block mb-1">Longitude</label>
+            <input id="lon" name="lon" type="number" step="any" required class="w-full bg-gray-700 rounded px-2 py-1" />
+          </div>
+        </div>
+        <div>
+          <label for="description" class="block mb-1">Description</label>
+          <textarea id="description" name="description" rows="3" class="w-full bg-gray-700 rounded px-2 py-1"></textarea>
+        </div>
+        <div>
+          <label for="images" class="block mb-1">Images (comma separated)</label>
+          <input id="images" name="images" class="w-full bg-gray-700 rounded px-2 py-1" />
+        </div>
+        <button type="submit" class="bg-blue-600 hover:bg-blue-500 px-4 py-2 rounded">Add/Update</button>
+      </form>
+      <div>
+        <h2 class="font-semibold mb-2">JSON Output</h2>
+        <textarea id="jsonOutput" rows="10" class="w-full bg-gray-700 rounded p-2"></textarea>
+        <button id="downloadBtn" class="mt-2 bg-purple-600 hover:bg-purple-500 px-4 py-2 rounded">Download</button>
+      </div>
+    </main>
+    <script>
+      fetch("nav.html").then(r => r.text()).then(html => {
+        document.getElementById("nav-placeholder").outerHTML = html;
+      });
+    </script>
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        const form = document.getElementById("siteForm");
+        const output = document.getElementById("jsonOutput");
+        let sites = [];
+        fetch("data/sites.json")
+          .then(r => r.json())
+          .then(d => {
+            sites = d;
+            output.value = JSON.stringify(sites, null, 2);
+          })
+          .catch(() => {});
+        form.addEventListener("submit", e => {
+          e.preventDefault();
+          const site = {
+            id: form.elements.siteId.value.trim(),
+            title: form.elements.title.value.trim(),
+            lat: parseFloat(form.elements.lat.value),
+            lon: parseFloat(form.elements.lon.value),
+            description: form.elements.description.value.trim(),
+            images: form.elements.images.value.split(',').map(s => s.trim()).filter(Boolean)
+          };
+          const idx = sites.findIndex(s => s.id === site.id);
+          if (idx >= 0) sites[idx] = site; else sites.push(site);
+          output.value = JSON.stringify(sites, null, 2);
+          form.reset();
+        });
+        document.getElementById("downloadBtn").addEventListener("click", () => {
+          const blob = new Blob([output.value], { type: "application/json" });
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = "sites.json";
+          a.click();
+          URL.revokeObjectURL(url);
+        });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add `data/sites.json` with sample content
- show an edit link in `nav.html`
- load sites and display markers on the map
- add a new `site-editor.html` page for managing site entries

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68777e3205e8832da2c1fc9243970dd8