### PR TITLE
Add hover-activated popups

### DIFF
--- a/map.html
+++ b/map.html
@@ -666,6 +666,8 @@
               html += `<img src='${s.images[0]}' class='mt-2 rounded w-32 h-auto'/>`;
             }
             m.bindPopup(html);
+            m.on("mouseover", () => m.openPopup());
+            m.on("mouseout", () => m.closePopup());
           });
         };
 
@@ -734,7 +736,7 @@
               const histDoseId = `hist-dose-${uid}`;
               const sliderDoseId = `slider-dose-${uid}`;
 
-              line.on("click", () => {
+              line.on("mouseover", () => {
                 let filtered = filterByDate(pts);
                 if (!filtered.length) filtered = pts;
                 const stats = computeStats(filtered);
@@ -972,9 +974,10 @@
                   drawCps(1);
                   drawDose(1);
                   document.getElementById(sliderCpsId).addEventListener("input", (e) => drawCps(parseInt(e.target.value)));
-                  document.getElementById(sliderDoseId).addEventListener("input", (e) => drawDose(parseInt(e.target.value)));
+                  document.getElementById(sliderDoseId).addEventListener("input", (e) => drawDose(parseInt(e.target.value))); 
                 }, 120);
               });
+              line.on("mouseout", () => trackPopup.classList.add("hidden"));
             } catch (e) {
               console.warn("skip", fname, e.message);
               const p = document.createElement("p");
@@ -1078,6 +1081,8 @@
               popupHtml += `<div class='mt-2 text-xs text-gray-400 text-center'>${dateStr}</div>`;
               popupHtml += `</div>`;
             marker.bindPopup(popupHtml);
+            marker.on("mouseover", () => marker.openPopup());
+            marker.on("mouseout", () => marker.closePopup());
           });
         }
 

--- a/map.js
+++ b/map.js
@@ -414,7 +414,7 @@ window.addEventListener("load", () => {
         const histDoseId = `hist-dose-${uid}`;
         const sliderDoseId = `slider-dose-${uid}`;
 
-        line.on("click", () => {
+        line.on("mouseover", () => {
           let filtered = filterByDate(pts);
           if (!filtered.length) filtered = pts;
           const stats = computeStats(filtered);
@@ -652,6 +652,7 @@ window.addEventListener("load", () => {
             document.getElementById(sliderDoseId).addEventListener("input", (e) => drawDose(parseInt(e.target.value)));
           }, 120);
         });
+        line.on("mouseout", () => trackPopup.classList.add("hidden"));
       } catch (e) {
         console.warn("skip", fname, e.message);
       }
@@ -752,6 +753,8 @@ window.addEventListener("load", () => {
       popupHtml += `<div class='mt-2 text-xs text-gray-400 text-center'>${dateStr}</div>`;
       popupHtml += `</div>`;
       marker.bindPopup(popupHtml);
+      marker.on("mouseover", () => marker.openPopup());
+      marker.on("mouseout", () => marker.closePopup());
     });
   }
 


### PR DESCRIPTION
## Summary
- make site marker popups open on hover
- show track popup when hovering over tracks
- show data point popup on hover

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687781f5b3dc832dae410d3452fb92dd