### PR TITLE
Support site image folders

### DIFF
--- a/data/images/site1/site1.jpg
+++ b/data/images/site1/site1.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/data/sites.json
+++ b/data/sites.json
@@ -5,6 +5,6 @@
     "lat": 44.5,
     "lon": 7.5,
     "description": "Short text",
-    "images": ["img/site1.jpg"]
+    "images": ["data/images/site1/site1.jpg"]
   }
 ]

--- a/site-editor.html
+++ b/site-editor.html
@@ -34,7 +34,8 @@
           <textarea id="description" name="description" rows="3" class="w-full bg-gray-700 rounded px-2 py-1"></textarea>
         </div>
         <div>
-          <label for="images" class="block mb-1">Images (comma separated)</label>
+          <label for="images" class="block mb-1">Image filenames (comma separated)</label>
+          <p class="text-sm text-gray-400 mb-1">Files will be loaded from <code>/data/images/&lt;ID&gt;/</code></p>
           <input id="images" name="images" class="w-full bg-gray-700 rounded px-2 py-1" />
         </div>
         <button type="submit" class="bg-blue-600 hover:bg-blue-500 px-4 py-2 rounded">Add/Update</button>
@@ -64,13 +65,18 @@
           .catch(() => {});
         form.addEventListener("submit", e => {
           e.preventDefault();
+          const siteId = form.elements.siteId.value.trim();
+          const imageNames = form.elements.images.value
+            .split(',')
+            .map(s => s.trim())
+            .filter(Boolean);
           const site = {
-            id: form.elements.siteId.value.trim(),
+            id: siteId,
             title: form.elements.title.value.trim(),
             lat: parseFloat(form.elements.lat.value),
             lon: parseFloat(form.elements.lon.value),
             description: form.elements.description.value.trim(),
-            images: form.elements.images.value.split(',').map(s => s.trim()).filter(Boolean)
+            images: imageNames.map(n => `data/images/${siteId}/${n}`)
           };
           const idx = sites.findIndex(s => s.id === site.id);
           if (idx >= 0) sites[idx] = site; else sites.push(site);


### PR DESCRIPTION
## Summary
- update data example to reference `data/images`
- note new image folder path in site editor form
- prefix images with `/data/images/<id>/` when generating JSON

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6877871a24a4832dba7bd05c5b08d8f5