### PR TITLE
Improve map UI glass aesthetics

### DIFF
--- a/map.html
+++ b/map.html
@@ -64,13 +64,30 @@
         pointer-events: none;
       }
       .track-line,
-      .data-dot {
+      .glass-dot {
         filter: drop-shadow(0 0 2px #000);
       }
       .site-icon {
         font-size: 24px;
         line-height: 24px;
         text-align: center;
+      }
+      .glass-dark {
+        background: rgba(31, 41, 55, 0.4);
+        backdrop-filter: blur(10px) saturate(150%);
+        -webkit-backdrop-filter: blur(10px) saturate(150%);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+      }
+      .glass-panel {
+        background: rgba(17, 24, 39, 0.4);
+        backdrop-filter: blur(8px) saturate(150%);
+        -webkit-backdrop-filter: blur(8px) saturate(150%);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+      }
+      .glass-dot {
+        stroke: rgba(255, 255, 255, 0.3);
+        stroke-width: 1px;
       }
     </style>
   </head>
@@ -99,10 +116,10 @@
       <div id="map" class="flex-1"></div>
       <aside
         id="sidebar"
-        class="fixed top-14 md:top-0 left-0 h-full w-72 max-w-full bg-gray-800/90 backdrop-blur-md p-4 space-y-4 overflow-y-auto transform -translate-x-full transition-transform z-[1000] md:relative md:translate-x-0 md:w-72 md:bg-opacity-100 text-gray-200"
+        class="fixed top-14 md:top-0 left-0 h-full w-72 max-w-full glass-dark p-4 space-y-4 overflow-y-auto transform -translate-x-full transition-transform z-[1000] md:relative md:translate-x-0 md:w-72 text-gray-200"
 
       >
-        <details class="group bg-gray-700/50 rounded-lg p-2">
+        <details class="group glass-panel rounded-lg p-2">
           <summary class="cursor-pointer font-medium flex items-center hover:bg-gray-600/40 rounded transition-colors">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -122,7 +139,7 @@
           <ul id="trackList" class="mt-2 space-y-2 text-sm"></ul>
         </details>
 
-        <details class="group bg-gray-700/50 rounded-lg p-2">
+        <details class="group glass-panel rounded-lg p-2">
           <summary class="cursor-pointer font-medium flex items-center hover:bg-gray-600/40 rounded transition-colors">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -140,7 +157,7 @@
           <ul id="siteList" class="mt-2 space-y-2 text-sm"></ul>
         </details>
 
-        <details class="group bg-gray-700/50 rounded-lg p-2">
+        <details class="group glass-panel rounded-lg p-2">
           <summary class="cursor-pointer font-medium flex items-center hover:bg-gray-600/40 rounded transition-colors">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -210,7 +227,7 @@
           </div>
         </details>
 
-        <details class="group bg-gray-700/50 rounded-lg p-2">
+        <details class="group glass-panel rounded-lg p-2">
           <summary class="cursor-pointer font-medium flex items-center hover:bg-gray-600/40 rounded transition-colors">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -322,7 +339,7 @@
 
       window.addEventListener("load", () => {
         const styleElem = document.createElement("style");
-        styleElem.textContent = `.track-line, .data-dot { filter: drop-shadow(0 0 2px #000); }`;
+        styleElem.textContent = `.track-line, .glass-dot { filter: drop-shadow(0 0 2px #000); }`;
         document.head.appendChild(styleElem);
         /* ------------------ MAP ------------------ */
         const map = L.map("map", {
@@ -696,7 +713,7 @@
               );
             }
           });
-          styleElem.textContent = `.track-line, .data-dot { filter: drop-shadow(0 0 ${lineShadow}px #000); }`;
+          styleElem.textContent = `.track-line, .glass-dot { filter: drop-shadow(0 0 ${lineShadow}px #000); }`;
         };
 
         const fetchSites = async () => {
@@ -842,53 +859,53 @@
                     <h3 class='text-lg font-semibold'>${displayName}</h3>
                   </div>
                   <div class='grid grid-cols-3 gap-2 sm:gap-4 mb-4 text-center text-xs sm:text-sm'>
-                    <div class='bg-gray-900/40 p-2 rounded-lg shadow'>
+                    <div class='glass-panel p-2 rounded-lg'>
                       <div class='text-gray-400'>Dose min</div>
                       <div id='stat-min-dose-${uid}' class='text-lg font-semibold text-sky-400'>0</div>
                       <div class='text-gray-400'>µSv/h</div>
                     </div>
-                    <div class='bg-gray-900/40 p-2 rounded-lg shadow'>
+                    <div class='glass-panel p-2 rounded-lg'>
                       <div class='text-gray-400'>Dose avg</div>
                       <div id='stat-avg-dose-${uid}' class='text-lg font-semibold text-sky-400'>0</div>
                       <div class='text-gray-400'>µSv/h</div>
                     </div>
-                    <div class='bg-gray-900/40 p-2 rounded-lg shadow'>
+                    <div class='glass-panel p-2 rounded-lg'>
                       <div class='text-gray-400'>Dose max</div>
                       <div id='stat-max-dose-${uid}' class='text-lg font-semibold text-sky-400'>0</div>
                       <div class='text-gray-400'>µSv/h</div>
                     </div>
-                    <div class='bg-gray-900/40 p-2 rounded-lg shadow'>
+                    <div class='glass-panel p-2 rounded-lg'>
                       <div class='text-gray-400'>CPS min</div>
                       <div id='stat-min-cps-${uid}' class='text-lg font-semibold text-amber-400'>0</div>
                       <div class='text-gray-400'>cps</div>
                     </div>
-                    <div class='bg-gray-900/40 p-2 rounded-lg shadow'>
+                    <div class='glass-panel p-2 rounded-lg'>
                       <div class='text-gray-400'>CPS avg</div>
                       <div id='stat-avg-cps-${uid}' class='text-lg font-semibold text-amber-400'>0</div>
                       <div class='text-gray-400'>cps</div>
                     </div>
-                    <div class='bg-gray-900/40 p-2 rounded-lg shadow'>
+                    <div class='glass-panel p-2 rounded-lg'>
                       <div class='text-gray-400'>CPS max</div>
                       <div id='stat-max-cps-${uid}' class='text-lg font-semibold text-amber-400'>0</div>
                       <div class='text-gray-400'>cps</div>
                     </div>
                   </div>
                   <div class='grid md:grid-cols-2 md:grid-rows-2 gap-4 text-white'>
-                    <div class='bg-gray-900/40 p-4 rounded-lg shadow'>
+                    <div class='glass-panel p-4 rounded-lg'>
                       <label class='block text-xs mb-1'>CPS Avg window: <span id='valCps-${uid}'>1</span></label>
                       <input type='range' min='1' max='50' value='1' id='${sliderCpsId}' class='w-full mb-2 accent-teal-500'>
                       <div id='${plotCpsId}' class='w-full h-96'></div>
                     </div>
-                    <div class='bg-gray-900/40 p-4 rounded-lg shadow'>
+                    <div class='glass-panel p-4 rounded-lg'>
                       <h4 class='text-sm font-semibold mb-2'>CPS histogram</h4>
                       <div id='${histCpsId}' class='w-full h-96'></div>
                     </div>
-                    <div class='bg-gray-900/40 p-4 rounded-lg shadow'>
+                    <div class='glass-panel p-4 rounded-lg'>
                       <label class='block text-xs mb-1'>Dose Avg window: <span id='valDose-${uid}'>1</span></label>
                       <input type='range' min='1' max='50' value='1' id='${sliderDoseId}' class='w-full mb-2 accent-teal-500'>
                       <div id='${plotDoseId}' class='w-full h-96'></div>
                     </div>
-                    <div class='bg-gray-900/40 p-4 rounded-lg shadow'>
+                    <div class='glass-panel p-4 rounded-lg'>
                       <h4 class='text-sm font-semibold mb-2'>Dose histogram</h4>
                       <div id='${histDoseId}' class='w-full h-96'></div>
                     </div>
@@ -1152,7 +1169,7 @@
               color: color,
               fillOpacity: 0.5,
               weight: 0,
-              className: "data-dot",
+              className: "data-dot glass-dot",
             }).addTo(pointLayer);
 
             const dateStr =
@@ -1164,19 +1181,19 @@
               let popupHtml = `<div class='prose prose-sm prose-invert'>`;
               popupHtml +=
                 `<div class='grid grid-cols-${cols} gap-2 text-center text-xs'>` +
-                `<div class='bg-gray-900/40 p-2 rounded-lg shadow'>` +
+                `<div class='glass-panel p-2 rounded-lg'>` +
                 `<div class='text-gray-400'>Dose</div>` +
                 `<div class='text-lg font-semibold text-sky-400'>${p.dose.toFixed(3)}</div>` +
                 `<div class='text-gray-400'>µSv/h</div>` +
                 `</div>` +
-                `<div class='bg-gray-900/40 p-2 rounded-lg shadow'>` +
+                `<div class='glass-panel p-2 rounded-lg'>` +
                 `<div class='text-gray-400'>CPS</div>` +
                 `<div class='text-lg font-semibold text-amber-400'>${p.cps.toFixed(1)}</div>` +
                 `<div class='text-gray-400'>cps</div>` +
                 `</div>`;
               if (hasEnergy) {
                 popupHtml +=
-                  `<div class='bg-gray-900/40 p-2 rounded-lg shadow'>` +
+                  `<div class='glass-panel p-2 rounded-lg'>` +
                   `<div class='text-gray-400'>Energy</div>` +
                   `<div class='text-lg font-semibold text-purple-400'>${p.energy.toFixed(1)}</div>` +
                   `<div class='text-gray-400'>keV</div>` +

--- a/map.js
+++ b/map.js
@@ -5,7 +5,7 @@ const FALLBACK_TRACK_FILES = [
 
 window.addEventListener("load", () => {
   const styleElem = document.createElement("style");
-  styleElem.textContent = `.track-line, .data-dot { filter: drop-shadow(0 0 2px #000); }`;
+  styleElem.textContent = `.track-line, .glass-dot { filter: drop-shadow(0 0 2px #000); }`;
   document.head.appendChild(styleElem);
   /* ------------------ MAP ------------------ */
   const map = L.map("map", {
@@ -439,53 +439,53 @@ window.addEventListener("load", () => {
               <h3 class='text-lg font-semibold'>${fname.split("/").pop()}</h3>
             </div>
             <div class='grid grid-cols-3 gap-2 sm:gap-4 mb-4 text-center text-xs sm:text-sm'>
-              <div class='bg-gray-900/40 p-2 rounded-lg shadow'>
+              <div class='glass-panel p-2 rounded-lg'>
                 <div class='text-gray-400'>Dose min</div>
                 <div id='stat-min-dose-${uid}' class='text-lg font-semibold text-sky-400'>0</div>
                 <div class='text-gray-400'>µSv/h</div>
               </div>
-              <div class='bg-gray-900/40 p-2 rounded-lg shadow'>
+              <div class='glass-panel p-2 rounded-lg'>
                 <div class='text-gray-400'>Dose avg</div>
                 <div id='stat-avg-dose-${uid}' class='text-lg font-semibold text-sky-400'>0</div>
                 <div class='text-gray-400'>µSv/h</div>
               </div>
-              <div class='bg-gray-900/40 p-2 rounded-lg shadow'>
+              <div class='glass-panel p-2 rounded-lg'>
                 <div class='text-gray-400'>Dose max</div>
                 <div id='stat-max-dose-${uid}' class='text-lg font-semibold text-sky-400'>0</div>
                 <div class='text-gray-400'>µSv/h</div>
               </div>
-              <div class='bg-gray-900/40 p-2 rounded-lg shadow'>
+              <div class='glass-panel p-2 rounded-lg'>
                 <div class='text-gray-400'>CPS min</div>
                 <div id='stat-min-cps-${uid}' class='text-lg font-semibold text-amber-400'>0</div>
                 <div class='text-gray-400'>cps</div>
               </div>
-              <div class='bg-gray-900/40 p-2 rounded-lg shadow'>
+              <div class='glass-panel p-2 rounded-lg'>
                 <div class='text-gray-400'>CPS avg</div>
                 <div id='stat-avg-cps-${uid}' class='text-lg font-semibold text-amber-400'>0</div>
                 <div class='text-gray-400'>cps</div>
               </div>
-              <div class='bg-gray-900/40 p-2 rounded-lg shadow'>
+              <div class='glass-panel p-2 rounded-lg'>
                 <div class='text-gray-400'>CPS max</div>
                 <div id='stat-max-cps-${uid}' class='text-lg font-semibold text-amber-400'>0</div>
                 <div class='text-gray-400'>cps</div>
               </div>
             </div>
             <div class='grid md:grid-cols-2 md:grid-rows-2 gap-4 text-white'>
-              <div class='bg-gray-900/40 p-4 rounded-lg shadow'>
+              <div class='glass-panel p-4 rounded-lg'>
                 <label class='block text-xs mb-1'>CPS Avg window: <span id='valCps-${uid}'>1</span></label>
                 <input type='range' min='1' max='50' value='1' id='${sliderCpsId}' class='w-full mb-2 accent-teal-500'>
                 <div id='${plotCpsId}' class='w-full h-96'></div>
               </div>
-              <div class='bg-gray-900/40 p-4 rounded-lg shadow'>
+              <div class='glass-panel p-4 rounded-lg'>
                 <h4 class='text-sm font-semibold mb-2'>CPS histogram</h4>
                 <div id='${histCpsId}' class='w-full h-96'></div>
               </div>
-              <div class='bg-gray-900/40 p-4 rounded-lg shadow'>
+              <div class='glass-panel p-4 rounded-lg'>
                 <label class='block text-xs mb-1'>Dose Avg window: <span id='valDose-${uid}'>1</span></label>
                 <input type='range' min='1' max='50' value='1' id='${sliderDoseId}' class='w-full mb-2 accent-teal-500'>
                 <div id='${plotDoseId}' class='w-full h-96'></div>
               </div>
-              <div class='bg-gray-900/40 p-4 rounded-lg shadow'>
+              <div class='glass-panel p-4 rounded-lg'>
                 <h4 class='text-sm font-semibold mb-2'>Dose histogram</h4>
                 <div id='${histDoseId}' class='w-full h-96'></div>
               </div>
@@ -733,7 +733,7 @@ window.addEventListener("load", () => {
         color: color,
         fillOpacity: 0.5,
         weight: 0,
-        className: "data-dot",
+        className: "data-dot glass-dot",
       }).addTo(pointLayer);
 
       const dateStr =
@@ -745,19 +745,19 @@ window.addEventListener("load", () => {
       let popupHtml = `<div class='prose prose-sm prose-invert'>`;
       popupHtml +=
         `<div class='grid grid-cols-${cols} gap-2 text-center text-xs'>` +
-        `<div class='bg-gray-900/40 p-2 rounded-lg shadow'>` +
+        `<div class='glass-panel p-2 rounded-lg'>` +
         `<div class='text-gray-400'>Dose</div>` +
         `<div class='text-lg font-semibold text-sky-400'>${p.dose.toFixed(3)}</div>` +
         `<div class='text-gray-400'>µSv/h</div>` +
         `</div>` +
-        `<div class='bg-gray-900/40 p-2 rounded-lg shadow'>` +
+        `<div class='glass-panel p-2 rounded-lg'>` +
         `<div class='text-gray-400'>CPS</div>` +
         `<div class='text-lg font-semibold text-amber-400'>${p.cps.toFixed(1)}</div>` +
         `<div class='text-gray-400'>cps</div>` +
         `</div>`;
       if (hasEnergy) {
         popupHtml +=
-          `<div class='bg-gray-900/40 p-2 rounded-lg shadow'>` +
+          `<div class='glass-panel p-2 rounded-lg'>` +
           `<div class='text-gray-400'>Energy</div>` +
           `<div class='text-lg font-semibold text-purple-400'>${p.energy.toFixed(1)}</div>` +
           `<div class='text-gray-400'>keV</div>` +


### PR DESCRIPTION
## Summary
- add reusable glass style classes
- style the sidebar and popups with glass look
- tweak marker classes to use glass-dot styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68778d35c408832d904c49b3fdcabcb4