### PR TITLE
Fix legend overlap on desktop

### DIFF
--- a/map.html
+++ b/map.html
@@ -103,7 +103,7 @@
     </button>
     <div
       id="legend"
-      class="fixed bottom-24 right-4 bg-gray-800/80 text-gray-100 p-2 rounded-md text-xs z-[1000] hidden"
+      class="fixed bottom-24 right-4 md:top-16 md:left-4 md:bottom-auto md:right-auto bg-gray-800/80 text-gray-100 p-2 rounded-md text-xs z-[1000] hidden"
     >
       <div id="legend-label" class="text-center mb-1">Dose (µSv/h)</div>
       <div id="legend-bar" class="h-2 w-32 rounded mb-1" style="background: linear-gradient(to right, green, yellow, red);"></div>


### PR DESCRIPTION
## Summary
- reposition legend on `map.html` so it appears in the top-left on desktop views

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687790445d34832db999bc43a3fde591