### PR TITLE
Fix Map Controls menu styling

### DIFF
--- a/map.html
+++ b/map.html
@@ -206,7 +206,7 @@
           </div>
         </details>
 
-        <details class="group bg-gray-700/50 rounded-lg p-2">
+        <details class="group glass-panel rounded-lg p-2">
           <summary class="cursor-pointer font-medium flex items-center hover:bg-gray-600/40 rounded transition-colors">
             <svg
               xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary
- match Map Controls menu style with other collapsible panels

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_687793cd9ae4832d94634df3ceaf4f3c