### PR TITLE
Add desktop sidebar background

### DIFF
--- a/map.html
+++ b/map.html
@@ -95,6 +95,17 @@
         stroke: rgba(255, 255, 255, 0.3);
         stroke-width: 1px;
       }
+      @media (min-width: 768px) {
+        #sidebar::before {
+          content: "";
+          position: absolute;
+          inset: 0;
+          background: linear-gradient(to bottom right, #1e293b, #0f172a);
+          background-size: cover;
+          pointer-events: none;
+          z-index: -1;
+        }
+      }
     </style>
   </head>
   <body class="bg-gray-900 text-gray-200 pt-14">


### PR DESCRIPTION
## Summary
- add a media query to show a gradient background behind the frosted sidebar on larger screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877942f025c832d956109e0a16b4e16