### PR TITLE
Refine site circle glow

### DIFF
--- a/map.html
+++ b/map.html
@@ -107,15 +107,17 @@
         }
 
       @keyframes siteGlow {
-        0%, 100% { fill-opacity: 0.2; }
-        50% { fill-opacity: 0.6; }
+        0%, 100% { fill-opacity: 0.15; }
+        50% { fill-opacity: 0.4; }
       }
       .site-glow {
         stroke: none;
         fill: #2563eb;
         filter: blur(4px);
-        animation: siteGlow 2s ease-in-out infinite;
-
+        fill-opacity: 0.15;
+      }
+      .site-glow-anim {
+        animation: siteGlow 1.5s ease-in-out;
       }
     </style>
   </head>
@@ -802,6 +804,18 @@
           return computeStats(pts);
         };
 
+        const triggerGlow = (circle) => {
+          const el = circle.getElement();
+          if (el) {
+            el.classList.add("site-glow-anim");
+            el.addEventListener(
+              "animationend",
+              () => el.classList.remove("site-glow-anim"),
+              { once: true }
+            );
+          }
+        };
+
         const updateSiteCircles = () => {
           Object.values(siteCircles).forEach((c) => map.removeLayer(c));
           Object.keys(siteCircles).forEach((k) => delete siteCircles[k]);
@@ -811,10 +825,11 @@
               radius: siteRadius,
               stroke: false,
               fillColor: "#2563eb",
-              fillOpacity: 0.2,
+              fillOpacity: 0.15,
               className: "site-glow",
               renderer: L.svg(),
             }).addTo(map);
+            triggerGlow(c);
             siteCircles[id] = c;
           });
         };
@@ -890,6 +905,10 @@
 
             m.on("mouseover", () => m.openPopup());
             m.on("mouseout", () => m.closePopup());
+            m.on("click", () => {
+              const c = siteCircles[id];
+              if (c) triggerGlow(c);
+            });
 
           });
           updateSiteCircles();


### PR DESCRIPTION
## Summary
- tone down site circle opacity
- add optional glow animation
- trigger glow on site click and when circle updates

## Testing
- `No automated tests`

------
https://chatgpt.com/codex/tasks/task_e_687796ac6538832d88b2201408127911