### PR TITLE
Darken green color on legend

### DIFF
--- a/map.html
+++ b/map.html
@@ -136,7 +136,7 @@
       class="fixed bottom-24 right-4 md:top-16 md:left-4 md:bottom-auto md:right-auto glass-dark text-gray-100 p-2 rounded-md text-xs z-[1000] hidden"
     >
       <div id="legend-label" class="text-center mb-1">Dose (µSv/h)</div>
-      <div id="legend-bar" class="h-2 w-32 rounded mb-1" style="background: linear-gradient(to right, green, yellow, red);"></div>
+      <div id="legend-bar" class="h-2 w-32 rounded mb-1" style="background: linear-gradient(to right, #006000, yellow, red);"></div>
       <div class="flex justify-between">
         <span id="legend-min">0</span>
         <span id="legend-max">0</span>

--- a/map.js
+++ b/map.js
@@ -183,9 +183,10 @@ window.addEventListener("load", () => {
     if (val === 0) return "#777"; // zero measurements grey
     const t = Math.max(0, Math.min(1, (val - min) / (max - min || 1e-9)));
     let r, g;
+    const darkG = 96; // darker starting green
     if (t <= 0.5) {
       r = Math.round(t * 2 * 255); // dark green -> yellow
-      g = Math.round(128 + t * 2 * 127); // start from darker green
+      g = Math.round(darkG + t * 2 * (255 - darkG));
     } else {
       r = 255;
       g = Math.round(255 * (1 - (t - 0.5) * 2)); // yellow -> red


### PR DESCRIPTION
## Summary
- adjust the color scale to use a darker green for low values
- update the fallback legend gradient

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68779823c324832d9fde1b2b043c2944