### PR TITLE
Match popup line plot colors to histograms

### DIFF
--- a/map.html
+++ b/map.html
@@ -1127,7 +1127,7 @@
                           mode: "lines",
                           line: {
                             width: 2,
-                            color,
+                            color: "#f59e0b",
                           },
                         },
                       ],
@@ -1162,7 +1162,7 @@
                           mode: "lines",
                           line: {
                             width: 2,
-                            color,
+                            color: "#38bdf8",
                           },
                         },
                       ],

--- a/map.js
+++ b/map.js
@@ -561,7 +561,7 @@ window.addEventListener("load", () => {
                     mode: "lines",
                     line: {
                       width: 2,
-                      color,
+                      color: "#f59e0b",
                     },
                   },
                 ],
@@ -596,7 +596,7 @@ window.addEventListener("load", () => {
                     mode: "lines",
                     line: {
                       width: 2,
-                      color,
+                      color: "#38bdf8",
                     },
                   },
                 ],


### PR DESCRIPTION
## Summary
- tweak popup line plot colors to use histogram colors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687799190aac832db538e6d03ca77a58