### PR TITLE
Add tile for popup date

### DIFF
--- a/map.html
+++ b/map.html
@@ -1347,8 +1347,9 @@
                   `<div class='text-gray-400'>keV</div>` +
                   `</div>`;
               }
-              popupHtml += `</div>`;
-              popupHtml += `<div class='mt-2 text-xs text-gray-400 text-center'>${dateStr}</div>`;
+              popupHtml +=
+                `<div class='glass-panel py-1 rounded-lg col-span-${cols} text-gray-400'>${dateStr}</div>` +
+                `</div>`;
               popupHtml += `</div>`;
             marker.bindPopup(popupHtml);
             marker.on("mouseover", () => marker.openPopup());

--- a/map.js
+++ b/map.js
@@ -765,8 +765,9 @@ window.addEventListener("load", () => {
           `<div class='text-gray-400'>keV</div>` +
           `</div>`;
       }
-      popupHtml += `</div>`;
-      popupHtml += `<div class='mt-2 text-xs text-gray-400 text-center'>${dateStr}</div>`;
+      popupHtml +=
+        `<div class='glass-panel py-1 rounded-lg col-span-${cols} text-gray-400'>${dateStr}</div>` +
+        `</div>`;
       popupHtml += `</div>`;
       marker.bindPopup(popupHtml);
       marker.on("mouseover", () => marker.openPopup());


### PR DESCRIPTION
## Summary
- style dot popup date/time info inside a glass-panel tile

## Testing
- `node -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687799b035cc832da93467dc54e169a3