### PR TITLE
Add frosted glass to track popup

### DIFF
--- a/map.html
+++ b/map.html
@@ -91,6 +91,10 @@
         border: 1px solid rgba(255, 255, 255, 0.1);
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
       }
+      #trackPopup {
+        backdrop-filter: blur(8px) saturate(150%);
+        -webkit-backdrop-filter: blur(8px) saturate(150%);
+      }
       .glass-dot {
         stroke: rgba(255, 255, 255, 0.3);
         stroke-width: 1px;

--- a/map.js
+++ b/map.js
@@ -5,7 +5,8 @@ const FALLBACK_TRACK_FILES = [
 
 window.addEventListener("load", () => {
   const styleElem = document.createElement("style");
-  styleElem.textContent = `.track-line, .glass-dot { filter: drop-shadow(0 0 2px #000); }`;
+  styleElem.textContent =
+    `.track-line, .glass-dot { filter: drop-shadow(0 0 2px #000); }\n#trackPopup { backdrop-filter: blur(8px) saturate(150%); -webkit-backdrop-filter: blur(8px) saturate(150%); }`;
   document.head.appendChild(styleElem);
   /* ------------------ MAP ------------------ */
   const map = L.map("map", {
@@ -355,7 +356,8 @@ window.addEventListener("load", () => {
         );
       }
     });
-    styleElem.textContent = `.track-line, .data-dot { filter: drop-shadow(0 0 ${lineShadow}px #000); }`;
+    styleElem.textContent =
+      `.track-line, .data-dot { filter: drop-shadow(0 0 ${lineShadow}px #000); }\n#trackPopup { backdrop-filter: blur(8px) saturate(150%); -webkit-backdrop-filter: blur(8px) saturate(150%); }`;
   };
 
   /* ------------------ MAIN LOAD ------------------ */


### PR DESCRIPTION
## Summary
- style track popup overlay with a frosted glass backdrop
- keep map.js in sync with added style

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68779a8a6154832da7137c0acc20ce2c