### PR TITLE
Adjust green hue in map color scale

### DIFF
--- a/map.js
+++ b/map.js
@@ -183,7 +183,7 @@ window.addEventListener("load", () => {
     if (val === 0) return "#777"; // zero measurements grey
     const t = Math.max(0, Math.min(1, (val - min) / (max - min || 1e-9)));
     let r, g;
-    const darkG = 96; // darker starting green
+    const darkG = 60; // even darker starting green
     if (t <= 0.5) {
       r = Math.round(t * 2 * 255); // dark green -> yellow
       g = Math.round(darkG + t * 2 * (255 - darkG));


### PR DESCRIPTION
## Summary
- tweak the starting green in the map's color scale to a darker shade

## Testing
- `node -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68779be9d418832daa472872cea6e6df