### PR TITLE
Fix range slider plotting

### DIFF
--- a/map.html
+++ b/map.html
@@ -1130,7 +1130,7 @@
                           x,
                           y: vals,
                           name: "Rate (cps)",
-                          type: "scattergl",
+                          type: "scatter",
                           mode: "lines",
                           line: {
                             width: 2,
@@ -1165,7 +1165,7 @@
                           x,
                           y: vals,
                           name: "Dose (µSv/h)",
-                          type: "scattergl",
+                          type: "scatter",
                           mode: "lines",
                           line: {
                             width: 2,

--- a/map.js
+++ b/map.js
@@ -560,7 +560,7 @@ window.addEventListener("load", () => {
                     x,
                     y: vals,
                     name: "Rate (cps)",
-                    type: "scattergl",
+                    type: "scatter",
                     mode: "lines",
                     line: {
                       width: 2,
@@ -595,7 +595,7 @@ window.addEventListener("load", () => {
                     x,
                     y: vals,
                     name: "Dose (µSv/h)",
-                    type: "scattergl",
+                    type: "scatter",
                     mode: "lines",
                     line: {
                       width: 2,


### PR DESCRIPTION
## Summary
- adjust Plotly trace type for range sliders in track popup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68779caa73e8832da4c9696b1f2f1364