### PR TITLE
Auto update track index

### DIFF
--- a/data/track_index.json
+++ b/data/track_index.json
@@ -1,3 +1,4 @@
 [
-  "data/Track 11 Jul 2025 22-19-23.rctrk"
+  "data/Track 11 Jul 2025 22-19-23.rctrk",
+  "data/Track 16 Jul 2025 13-37-42.rctrk"
 ]

--- a/update_track_index.js
+++ b/update_track_index.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+
+// Directory containing track files
+const dataDir = path.join(__dirname, 'data');
+const indexPath = path.join(dataDir, 'track_index.json');
+
+// List .rctrk files in the data directory
+const trackFiles = fs
+  .readdirSync(dataDir)
+  .filter(f => f.toLowerCase().endsWith('.rctrk'))
+  .sort()
+  .map(f => `data/${f}`);
+
+fs.writeFileSync(indexPath, JSON.stringify(trackFiles, null, 2) + '\n');
+console.log(`Updated ${indexPath} with ${trackFiles.length} track file(s)`);


### PR DESCRIPTION
## Summary
- add a small Node script to regenerate `data/track_index.json`
- run the script to include all `.rctrk` files in `data`

## Testing
- `node update_track_index.js`


------
https://chatgpt.com/codex/tasks/task_e_6877a5cf237c832dad2317d59baa00b9