### PR TITLE
Fix closing brace in map.html

### DIFF
--- a/map.html
+++ b/map.html
@@ -113,6 +113,7 @@
           pointer-events: none;
           z-index: -1;
         }
+      }
 
       @keyframes siteGlow {
         0%, 100% { fill-opacity: 0.25; }


### PR DESCRIPTION
## Summary
- close the `@media` block in `map.html` to restore valid CSS
- verified CSS brace balance with a Python script

## Testing
- `python3 - <<'EOF'
import re
text=open('map.html').read()
style=re.search(r'<style>(.*?)</style>',text, re.S).group(1)
stack=[]
for ch in style:
    if ch=='{': stack.append('{')
    elif ch=='}': stack.pop()
print('Remaining', len(stack))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6877d3d5f70c832d9327b6caa219d3ca