### PR TITLE
Fix update_site_images missing list

### DIFF
--- a/update_site_images.js
+++ b/update_site_images.js
@@ -20,14 +20,18 @@ try {
 
 sites.forEach(site => {
   const siteDir = path.join(imagesDir, site.id);
+  let files = [];
   if (fs.existsSync(siteDir) && fs.statSync(siteDir).isDirectory()) {
-    const files = fs
+    files = fs
       .readdirSync(siteDir)
       .filter(f => /\.(jpe?g|png|gif|webp)$/i.test(f))
       .sort();
-    if (files.length > 0) {
-      site.images = files.map(f => `data/images/${site.id}/${f}`);
-    }
+  }
+
+  if (files.length > 0) {
+    site.images = files.map(f => `data/images/${site.id}/${f}`);
+  } else {
+    site.images = [];
   }
 });
 


### PR DESCRIPTION
## Summary
- handle missing images when regenerating site data

## Testing
- `node update_site_images.js`

------
https://chatgpt.com/codex/tasks/task_e_6877d3f0f598832d9942afb0f875fb30