### PR TITLE
Remove admin login requirement

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -14,31 +14,7 @@
         document.getElementById('nav-placeholder').outerHTML = html;
       });
 
-      async function authCheck() {
-        const r = await fetch('/api/auth-check');
-        return (await r.json()).loggedIn;
-      }
-
-      async function showLogin() {
-        const content = document.getElementById('content');
-        content.innerHTML = `<form id="loginForm" class="bg-gray-800 p-6 rounded space-y-4 max-w-sm mx-auto">
-            <h1 class="text-xl font-semibold">Admin Login</h1>
-            <input type="password" id="pw" class="w-full bg-gray-700 rounded px-3 py-2" placeholder="Password" />
-            <button class="bg-blue-600 hover:bg-blue-500 px-4 py-2 rounded w-full">Login</button>
-          </form>`;
-        document.getElementById('loginForm').addEventListener('submit', async e => {
-          e.preventDefault();
-          const res = await fetch('/login', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ password: document.getElementById('pw').value })
-          });
-          if (res.ok) loadDashboard();
-          else alert('Invalid password');
-        });
-      }
-
-      async function loadDashboard() {
+        async function loadDashboard() {
         const content = document.getElementById('content');
         content.innerHTML = `
           <h1 class="text-2xl font-semibold">Admin Dashboard</h1>
@@ -180,8 +156,7 @@
       }
 
       (async () => {
-        if (await authCheck()) loadDashboard();
-        else showLogin();
+        loadDashboard();
       })();
     </script>
   </body>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   },
   "dependencies": {
     "express": "^4.19.2",
-    "express-session": "^1.17.3",
     "multer": "^1.4.5"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,40 +1,21 @@
 const express = require('express');
-const session = require('express-session');
 const fs = require('fs');
 const path = require('path');
 const multer = require('multer');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
-const PASSWORD = process.env.ADMIN_PASSWORD || 'admin';
 const DATA_DIR = path.join(__dirname, 'data');
 
 app.use(express.json());
-app.use(session({ secret: 'ocde-secret', resave: false, saveUninitialized: false }));
+// No session or authentication required
 
 // Authentication middleware
 function requireAuth(req, res, next) {
-  if (req.session.loggedIn) return next();
-  res.status(401).json({ error: 'Unauthorized' });
+  // Authentication removed; all requests are allowed
+  return next();
 }
 
-app.post('/login', (req, res) => {
-  const { password } = req.body;
-  if (password === PASSWORD) {
-    req.session.loggedIn = true;
-    res.json({ ok: true });
-  } else {
-    res.status(401).json({ error: 'Invalid password' });
-  }
-});
-
-app.post('/logout', (req, res) => {
-  req.session.destroy(() => res.json({ ok: true }));
-});
-
-app.get('/api/auth-check', (req, res) => {
-  res.json({ loggedIn: !!req.session.loggedIn });
-});
 
 // Serve static files
 app.use(express.static(__dirname));


### PR DESCRIPTION
## Summary
- allow direct access to admin endpoints by removing auth logic
- simplify dashboard page by dropping login form
- remove unused express-session dependency

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688936a62a44832da834d651e66b15ab