### PR TITLE
Add captions and editing for site images

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -41,6 +41,7 @@
             </div>
             <textarea id="description" rows="2" class="w-full bg-gray-700 rounded px-2 py-1" placeholder="Description"></textarea>
             <input id="references" placeholder="References comma separated" class="w-full bg-gray-700 rounded px-2 py-1" />
+            <div id="imageCaptions" class="space-y-2"></div>
             <div class="flex gap-2">
               <button id="siteFormSave" class="bg-green-600 hover:bg-green-500 px-4 py-1 rounded">Save</button>
               <button type="button" id="siteFormCancel" class="hidden bg-gray-600 hover:bg-gray-500 px-4 py-1 rounded">Cancel</button>
@@ -91,7 +92,9 @@
               const site = sites.find(s => s.id === siteId);
               if (site) {
                 if (!site.images) site.images = [];
+                if (!site.captions) site.captions = [];
                 site.images.push(file);
+                site.captions.push('');
                 await fetch('/api/sites', {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json' },
@@ -114,6 +117,7 @@
             lon: +f.lon.value,
             description: f.description.value.trim(),
             images: editingSite && editingSite.images ? editingSite.images : [],
+            captions: Array.from(document.querySelectorAll('#imageCaptions .captionInput')).map(i => i.value.trim()),
             references: f.references.value.split(',').map(s=>s.trim()).filter(Boolean)
           };
           await fetch('/api/sites', {
@@ -137,6 +141,7 @@
         f.lon.value = site.lon;
         f.description.value = site.description || '';
         f.references.value = (site.references || []).join(', ');
+        renderCaptions(site);
         document.getElementById('siteFormSave').textContent = 'Update';
         document.getElementById('siteFormCancel').classList.remove('hidden');
         f.scrollIntoView({ behavior: 'smooth' });
@@ -147,8 +152,23 @@
         const f = document.getElementById('siteForm');
         f.reset();
         f.siteId.disabled = false;
+        document.getElementById('imageCaptions').innerHTML = '';
         document.getElementById('siteFormSave').textContent = 'Save';
         document.getElementById('siteFormCancel').classList.add('hidden');
+      }
+
+      function renderCaptions(site) {
+        const container = document.getElementById('imageCaptions');
+        container.innerHTML = '';
+        if (!site || !site.images) return;
+        const caps = site.captions || [];
+        site.images.forEach((img, i) => {
+          const div = document.createElement('div');
+          div.className = 'flex items-center gap-2';
+          div.innerHTML = `<img src="${img}" class="h-16 rounded" />` +
+            `<input data-index="${i}" class="captionInput flex-1 bg-gray-700 rounded px-2 py-1" placeholder="Caption" value="${caps[i] || ''}" />`;
+          container.appendChild(div);
+        });
       }
 
       async function loadTracks() {

--- a/data/sites.json
+++ b/data/sites.json
@@ -8,6 +8,9 @@
     "images": [
       "data/images/site1/site1.jpg"
     ],
+    "captions": [
+      "Main view of Site 1"
+    ],
     "references": [
       "https://example.com/site1"
     ]
@@ -22,6 +25,11 @@
       "data/images/fisica/fisica1.jpeg",
       "data/images/fisica/fisica2.png",
       "data/images/fisica/fisica3.jpg"
+    ],
+    "captions": [
+      "Department entrance",
+      "Lecture hall",
+      "Research lab"
     ],
     "references": [
       "https://www.ph.unito.it"

--- a/map.html
+++ b/map.html
@@ -572,12 +572,17 @@
             imagePopup.classList.remove("opacity-100");
           });
         let galleryImages = [];
+        let galleryCaptions = [];
+        let galleryTitle = '';
         let galleryIndex = 0;
-        const openImagePopup = (images, idx, title, desc) => {
+        const openImagePopup = (images, captions, idx, title, desc) => {
           galleryImages = images;
+          galleryCaptions = captions || [];
+          galleryTitle = title;
           galleryIndex = idx;
           imagePopupImg.src = images[idx];
-          imagePopupCaption.innerHTML = `<h3 class='font-semibold mb-1'>${title}</h3>` + (desc ? `<p>${desc}</p>` : "");
+          const cap = galleryCaptions[idx] || desc || '';
+          imagePopupCaption.innerHTML = `<h3 class='font-semibold mb-1'>${title}</h3>` + (cap ? `<p>${cap}</p>` : '');
           imagePopup.classList.remove("pointer-events-none", "opacity-0");
           imagePopup.classList.add("opacity-100");
         };
@@ -585,6 +590,8 @@
           if (!galleryImages.length) return;
           galleryIndex = (galleryIndex + dir + galleryImages.length) % galleryImages.length;
           imagePopupImg.src = galleryImages[galleryIndex];
+          const cap = galleryCaptions[galleryIndex] || '';
+          imagePopupCaption.innerHTML = `<h3 class='font-semibold mb-1'>${galleryTitle}</h3>` + (cap ? `<p>${cap}</p>` : '');
         };
         imagePopupPrev.addEventListener("click", () => showGalleryImage(-1));
         imagePopupNext.addEventListener("click", () => showGalleryImage(1));
@@ -923,7 +930,8 @@
             if (Array.isArray(s.images) && s.images.length) {
               html += `<h4>Gallery</h4><div class='flex gap-2 mt-2 overflow-x-auto border border-gray-700 rounded p-2 bg-gray-900/40'>`;
               s.images.forEach((img, i) => {
-                html += `<img src='${img}' data-index='${i}' class='site-thumb w-16 h-16 object-cover rounded cursor-pointer'/>`;
+                const cap = (s.captions || [])[i] || '';
+                html += `<img src='${img}' data-index='${i}' class='site-thumb w-16 h-16 object-cover rounded cursor-pointer' title='${cap}'/>`;
               });
               html += `</div>`;
             }
@@ -943,7 +951,8 @@
               if (Array.isArray(s.images) && s.images.length) {
                 content += `<h4>Gallery</h4><div class='flex gap-2 mt-2 overflow-x-auto border border-gray-700 rounded p-2 bg-gray-900/40'>`;
                 s.images.forEach((img, i) => {
-                  content += `<img src='${img}' data-index='${i}' class='site-thumb w-16 h-16 object-cover rounded cursor-pointer'/>`;
+                  const cap = (s.captions || [])[i] || '';
+                  content += `<img src='${img}' data-index='${i}' class='site-thumb w-16 h-16 object-cover rounded cursor-pointer' title='${cap}'/>`;
                 });
                 content += `</div>`;
               }
@@ -972,7 +981,7 @@
               popupEl.querySelectorAll('.site-thumb').forEach((imgEl) => {
                 imgEl.addEventListener('click', () => {
                   const idx = parseInt(imgEl.dataset.index);
-                  openImagePopup(s.images, idx, s.title ?? '', s.description ?? '');
+                  openImagePopup(s.images, s.captions || [], idx, s.title ?? '', s.description ?? '');
                 });
               });
             });


### PR DESCRIPTION
## Summary
- support captions for site images
- enable editing captions in the admin dashboard
- display captions in gallery popups
- store example captions in `sites.json`

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68894b7a2ce8832d9f25eda3823dc0e8