### PR TITLE
Add satellite basemap and north indicator

### DIFF
--- a/map.html
+++ b/map.html
@@ -66,6 +66,14 @@
         border-radius: 0.25rem;
         font-size: 0.75rem;
       }
+      .north-indicator {
+        background: rgba(31, 41, 55, 0.8);
+        color: #fff;
+        padding: 2px 6px;
+        border-radius: 0.25rem;
+        font-size: 0.75rem;
+        pointer-events: none;
+      }
       #legend {
         pointer-events: none;
       }
@@ -306,6 +314,7 @@
                 <option value="topo">Topographic</option>
                 <option value="osm">OSM</option>
                 <option value="hot">OSM HOT</option>
+                <option value="satellite">Satellite</option>
               </select>
             </div>
             <div>

--- a/map.js
+++ b/map.js
@@ -42,6 +42,14 @@ window.addEventListener("load", () => {
       "https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
       { maxZoom: 20, attribution: "&copy; OpenStreetMap contributors, HOT" }
     ),
+    satellite: L.tileLayer(
+      "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+      {
+        maxZoom: 19,
+        attribution:
+          "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community",
+      }
+    ),
   };
   let currentBase = baseLayers.dark.addTo(map);
   let baseIsDark = true;
@@ -70,6 +78,14 @@ window.addEventListener("load", () => {
   map.on("mousemove", (e) => {
     coordsControl._div.innerHTML = `Lat: ${e.latlng.lat.toFixed(5)} Lon: ${e.latlng.lng.toFixed(5)}`;
   });
+
+  const northControl = L.control({ position: "topright" });
+  northControl.onAdd = function () {
+    this._div = L.DomUtil.create("div", "north-indicator");
+    this._div.innerHTML = "\u25B2 N"; // ▲ N
+    return this._div;
+  };
+  northControl.addTo(map);
 
   /* ------------------ STATE ------------------ */
   const allPoints = [];


### PR DESCRIPTION
## Summary
- support 'Satellite' basemap layer
- show north indicator on map

## Testing
- `node --version`
- `npm start` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688a2d433844832d90e8fd737cc732a8