### PR TITLE
Display DATA_DIR on admin dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains the web interface and scripts for the OCDE project.
 
 The application uses a `data` folder to store uploaded tracks, images and JSON configuration files. By default the scripts expect this folder to be located at `path.join(__dirname, 'data')` relative to each script.
 
+The server exposes the path it is using via the `/api/data-dir` endpoint. The Admin Dashboard displays this value so you can confirm where files are being saved.
+
 You can override this location by defining the `DATA_DIR` environment variable when running the server or the update scripts. This allows you to keep your local data outside of the repository. For example:
 
 ```bash

--- a/admin.html
+++ b/admin.html
@@ -19,9 +19,15 @@
         const content = document.getElementById('content');
         content.innerHTML = `
           <h1 class="text-2xl font-semibold">Admin Dashboard</h1>
+          <p id="dataDir" class="text-sm text-gray-400"></p>
           <section id="siteSection" class="space-y-4"></section>
           <section id="trackSection" class="space-y-4"></section>
         `;
+        const resp = await fetch('/api/data-dir');
+        if (resp.ok) {
+          const { dataDir } = await resp.json();
+          document.getElementById('dataDir').textContent = `Data directory: ${dataDir}`;
+        }
         loadSites();
         loadTracks();
       }

--- a/server.js
+++ b/server.js
@@ -24,6 +24,11 @@ app.use(express.static(__dirname));
 const readJson = (file) => JSON.parse(fs.readFileSync(path.join(DATA_DIR, file), 'utf8'));
 const writeJson = (file, data) => fs.writeFileSync(path.join(DATA_DIR, file), JSON.stringify(data, null, 2));
 
+/* ----- CONFIG ENDPOINT ----- */
+app.get('/api/data-dir', requireAuth, (req, res) => {
+  res.json({ dataDir: DATA_DIR });
+});
+
 /* ----- SITE ENDPOINTS ----- */
 app.get('/api/sites', requireAuth, (req, res) => {
   res.json(readJson('sites.json'));
@@ -83,4 +88,5 @@ app.post('/api/images/:siteId', requireAuth, imageStorage.single('image'), (req,
 
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
+  console.log(`Using data directory: ${DATA_DIR}`);
 });


### PR DESCRIPTION
## Summary
- show the server data directory on Admin Dashboard
- expose `/api/data-dir` endpoint
- log data directory on server start
- document the new endpoint

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a2c6307f0832db2b51bf41f656ce2