### PR TITLE
Enhance tile readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,16 +14,17 @@
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <a
           href="map.html"
-          class="rounded-lg p-8 flex items-center justify-center space-x-2 bg-gray-800/60 bg-cover bg-center hover:bg-gray-700"
+          class="relative rounded-lg p-8 flex items-center justify-center space-x-2 bg-cover bg-center hover:bg-gray-700 text-white"
           style="background-image: url('https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=600&q=80')"
         >
+          <span class="absolute inset-0 bg-black/50 rounded-lg"></span>
           <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
             stroke-width="2"
-            class="w-6 h-6"
+            class="relative w-6 h-6"
           >
             <path
               d="M12 21s-6-5.5-6-10a6 6 0 1112 0c0 4.5-6 10-6 10z"
@@ -32,20 +33,21 @@
             />
             <circle cx="12" cy="11" r="2" fill="currentColor" stroke="none" />
           </svg>
-          <span class="text-lg font-medium">Radiation Map</span>
+          <span class="relative text-lg font-medium">Radiation Map</span>
         </a>
         <a
           href="about.html"
-          class="rounded-lg p-8 flex items-center justify-center space-x-2 bg-gray-800/60 bg-cover bg-center hover:bg-gray-700"
+          class="relative rounded-lg p-8 flex items-center justify-center space-x-2 bg-cover bg-center hover:bg-gray-700 text-white"
           style="background-image: url('https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=600&q=80')"
         >
+          <span class="absolute inset-0 bg-black/50 rounded-lg"></span>
           <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
             stroke-width="2"
-            class="w-6 h-6"
+            class="relative w-6 h-6"
           >
             <circle
               cx="12"
@@ -57,7 +59,7 @@
             <line x1="12" y1="10" x2="12" y2="16" />
             <circle cx="12" cy="7" r="1" fill="currentColor" stroke="none" />
           </svg>
-          <span class="text-lg font-medium">About Us</span>
+          <span class="relative text-lg font-medium">About Us</span>
         </a>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- add dark overlay layers to tiles on the home page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a37f7d7f4832dabe47c0be326acad