### PR TITLE
Show track info for single visible track markers

### DIFF
--- a/map.html
+++ b/map.html
@@ -1436,6 +1436,9 @@
           const visiblePoints = filterByDate(allPoints).filter(
             (p) => tracks[p.fname]?.visible
           );
+          const visibleTrackArr = Object.values(tracks).filter((t) => t.visible);
+          const singleTrack =
+            visibleTrackArr.length === 1 ? visibleTrackArr[0] : null;
           if (!visiblePoints.length) {
             pointLayer.clearLayers();
             legendLabel.textContent =
@@ -1511,8 +1514,17 @@
                 `</div>`;
               popupHtml += `</div>`;
             marker.bindPopup(popupHtml);
-            marker.on("mouseover", () => marker.openPopup());
-            marker.on("mouseout", () => marker.closePopup());
+            marker.on("mouseover", () => {
+              marker.openPopup();
+              if (singleTrack) showTrackInfo(singleTrack);
+            });
+            marker.on("mousemove", () => {
+              if (singleTrack) showTrackInfo(singleTrack);
+            });
+            marker.on("mouseout", () => {
+              marker.closePopup();
+              if (singleTrack) hideTrackInfo();
+            });
           });
         }
 

--- a/map.js
+++ b/map.js
@@ -743,6 +743,8 @@ window.addEventListener("load", () => {
     const visiblePoints = filterByDate(allPoints).filter(
       (p) => tracks[p.fname]?.visible
     );
+    const visibleTrackArr = Object.values(tracks).filter((t) => t.visible);
+    const singleTrack = visibleTrackArr.length === 1 ? visibleTrackArr[0] : null;
     if (!visiblePoints.length) {
       pointLayer.clearLayers();
       legend.classList.add("hidden");
@@ -819,8 +821,17 @@ window.addEventListener("load", () => {
         `</div>`;
       popupHtml += `</div>`;
       marker.bindPopup(popupHtml);
-      marker.on("mouseover", () => marker.openPopup());
-      marker.on("mouseout", () => marker.closePopup());
+      marker.on("mouseover", () => {
+        marker.openPopup();
+        if (singleTrack) showTrackInfo(singleTrack);
+      });
+      marker.on("mousemove", () => {
+        if (singleTrack) showTrackInfo(singleTrack);
+      });
+      marker.on("mouseout", () => {
+        marker.closePopup();
+        if (singleTrack) hideTrackInfo();
+      });
     });
   }
 


### PR DESCRIPTION
## Summary
- show track information when hovering over data dots if exactly one track is visible
- apply same logic in the standalone JS file

## Testing
- `npm test` *(fails: Missing script)*
- `node --check map.js`
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_688a9a62c1a8832db7c53c108b040ddb