### PR TITLE
Improve track parsing

### DIFF
--- a/map.html
+++ b/map.html
@@ -668,12 +668,13 @@
         };
 
         const parseFile = (text) => {
-          // .rctrk JSON
+          // .rctrk JSON (object with markers or plain array)
           try {
             const js = JSON.parse(text);
-            if (Array.isArray(js.markers)) {
+            const markers = Array.isArray(js) ? js : js.markers;
+            if (Array.isArray(markers)) {
               const factor = js.sv === false ? 0.01 : 1;
-              const points = js.markers
+              const points = markers
                 .map((m) => ({
                   lat: +m.lat,
                   lon: +m.lon,
@@ -686,6 +687,28 @@
               return { points, title: js.title };
             }
           } catch (_) {}
+
+          // Newline-delimited JSON
+          try {
+            const lines = text.trim().split(/\r?\n/);
+            if (lines.length > 1) {
+              const objs = lines.map((l) => JSON.parse(l));
+              if (objs.every((o) => typeof o === "object")) {
+                const points = objs
+                  .map((m) => ({
+                    lat: +m.lat,
+                    lon: +m.lon,
+                    dose: +(m.doseRate ?? m.dose_uSv_h ?? m.dose ?? 0),
+                    cps: +(m.countRate ?? m.cps ?? 0),
+                    energy: +(m.energy ?? m.energyValue ?? m.energy_ev ?? NaN),
+                    date: +m.date || 0,
+                  }))
+                  .filter((p) => !isNaN(p.lat) && !isNaN(p.lon));
+                return { points };
+              }
+            }
+          } catch (_) {}
+
           // CSV fallback (lat lon dose cps energy?)
           const parsed = Papa.parse(text.trim(), {
             dynamicTyping: true,

--- a/map.js
+++ b/map.js
@@ -178,12 +178,13 @@ window.addEventListener("load", () => {
   };
 
   const parseFile = (text) => {
-    // .rctrk JSON
+    // .rctrk JSON (object with markers or plain array)
     try {
       const js = JSON.parse(text);
-      if (Array.isArray(js.markers)) {
+      const markers = Array.isArray(js) ? js : js.markers;
+      if (Array.isArray(markers)) {
         const factor = js.sv === false ? 0.01 : 1;
-        return js.markers
+        return markers
           .map((m) => ({
             lat: +m.lat,
             lon: +m.lon,
@@ -195,6 +196,27 @@ window.addEventListener("load", () => {
           .filter((p) => !isNaN(p.lat) && !isNaN(p.lon));
       }
     } catch (_) {}
+
+    // Newline-delimited JSON
+    try {
+      const lines = text.trim().split(/\r?\n/);
+      if (lines.length > 1) {
+        const objs = lines.map((l) => JSON.parse(l));
+        if (objs.every((o) => typeof o === "object")) {
+          return objs
+            .map((m) => ({
+              lat: +m.lat,
+              lon: +m.lon,
+              dose: +(m.doseRate ?? m.dose_uSv_h ?? m.dose ?? 0),
+              cps: +(m.countRate ?? m.cps ?? 0),
+              energy: +(m.energy ?? m.energyValue ?? m.energy_ev ?? NaN),
+              date: +m.date || 0,
+            }))
+            .filter((p) => !isNaN(p.lat) && !isNaN(p.lon));
+        }
+      }
+    } catch (_) {}
+
     // CSV fallback (lat lon dose cps energy?)
     const parsed = Papa.parse(text.trim(), {
       dynamicTyping: true,


### PR DESCRIPTION
## Summary
- support more JSON formats when loading tracks

## Testing
- `npm test` *(fails: Missing script)*
- `node --check map.js`
- `node --check server.js`

------
https://chatgpt.com/codex/tasks/task_e_688d38e2a434832dba6ac0f7045d8583