### PR TITLE
Add colormap and scale options

### DIFF
--- a/map.html
+++ b/map.html
@@ -346,6 +346,24 @@
                 class="bg-gray-700 border border-gray-600 rounded-md px-2 py-1 w-full focus:outline-none"
               />
             </div>
+            <div>
+              <label for="colormapSelect" class="block mb-1 font-medium">Colormap</label>
+              <select
+                id="colormapSelect"
+                class="bg-gray-700 border border-gray-600 rounded-md px-2 py-1 w-full focus:outline-none"
+              >
+                <option value="rainbow">Rainbow</option>
+                <option value="viridis">Viridis</option>
+                <option value="plasma">Plasma</option>
+                <option value="magma">Magma</option>
+                <option value="turbo">Turbo</option>
+              </select>
+            </div>
+            <label class="flex items-center gap-2 text-gray-200 cursor-pointer" for="globalColorToggle">
+              <input type="checkbox" id="globalColorToggle" class="sr-only peer" />
+              <div class="w-11 h-6 bg-gray-600 rounded-full peer-checked:bg-blue-600 relative after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full"></div>
+              <span>Global scale</span>
+            </label>
           </div>
         </details>
 
@@ -574,6 +592,8 @@
         const lineShadowSlider = document.getElementById("lineShadowSlider");
         const showTrackDotsToggle = document.getElementById("showTrackDotsToggle");
         const dotOpacitySlider = document.getElementById("dotOpacitySlider");
+        const colormapSelect = document.getElementById("colormapSelect");
+        const globalColorToggle = document.getElementById("globalColorToggle");
         const showSiteCirclesToggle = document.getElementById("showSiteCirclesToggle");
         const siteRadiusSlider = document.getElementById("siteRadiusSlider");
         const siteRadiusVal = document.getElementById("siteRadiusVal");
@@ -634,6 +654,8 @@
         let lineShadow = 2;
         let showTrackDots = false;
         let dotOpacity = 0.5;
+        let globalScale = false;
+        let colorMap = 'rainbow';
         showSiteCirclesToggle.checked = true;
         let showSiteCircles = true;
         let siteRadius = parseFloat(siteRadiusSlider.value);
@@ -705,18 +727,75 @@
           return { points };
         };
 
+        const ramp = (colors, t) => {
+          t = Math.max(0, Math.min(1, t));
+          const n = colors.length - 1;
+          const i = Math.floor(t * n);
+          const f = t * n - i;
+          const c1 = colors[i];
+          const c2 = colors[Math.min(i + 1, n)];
+          const r = Math.round(c1[0] + f * (c2[0] - c1[0]));
+          const g = Math.round(c1[1] + f * (c2[1] - c1[1]));
+          const b = Math.round(c1[2] + f * (c2[2] - c1[2]));
+          return `rgb(${r},${g},${b})`;
+        };
+
+        const colorMaps = {
+          rainbow: (t) => ramp([
+            [0, 96, 0],
+            [255, 255, 0],
+            [255, 0, 0],
+          ], t),
+          viridis: (t) =>
+            ramp(
+              [
+                [68, 1, 84],
+                [59, 82, 139],
+                [33, 145, 140],
+                [94, 201, 97],
+                [253, 231, 37],
+              ],
+              t
+            ),
+          plasma: (t) =>
+            ramp(
+              [
+                [13, 8, 135],
+                [126, 3, 168],
+                [203, 71, 119],
+                [248, 149, 64],
+                [253, 231, 37],
+              ],
+              t
+            ),
+          magma: (t) =>
+            ramp(
+              [
+                [0, 0, 4],
+                [59, 15, 113],
+                [133, 28, 107],
+                [208, 59, 73],
+                [251, 253, 191],
+              ],
+              t
+            ),
+          turbo: (t) =>
+            ramp(
+              [
+                [48, 18, 59],
+                [37, 112, 219],
+                [0, 218, 115],
+                [255, 230, 32],
+                [250, 37, 0],
+              ],
+              t
+            ),
+        };
+
         const colorScale = (val, min, max) => {
-          if (val === 0) return "#777"; // zero measurements grey
+          if (val === 0) return "#777";
           const t = Math.max(0, Math.min(1, (val - min) / (max - min || 1e-9)));
-          let r, g;
-          if (t <= 0.5) {
-            r = Math.round(t * 2 * 255); // green -> yellow
-            g = 255;
-          } else {
-            r = 255;
-            g = Math.round(255 * (1 - (t - 0.5) * 2)); // yellow -> red
-          }
-          return `rgb(${r},${g},0)`;
+          return colorMaps[colorMap](t);
         };
 
         const animateCounter = (el, value, decimals = 0) => {
@@ -854,20 +933,44 @@
 
           const metric = document.getElementById("metricSelect").value;
           const visibleTracks = Object.values(tracks).filter((t) => t.visible);
-          const visiblePoints = visibleTracks.flatMap((t) => filterByDate(t.points));
-          if (!visiblePoints.length) return;
-          const vals = visiblePoints
-            .filter((p) => p.dose !== 0 || p.cps !== 0)
-            .map((p) => (metric === "dose" ? p.dose : p.cps));
-          const min = Math.min(...vals);
-          const max = Math.max(...vals);
+          if (!visibleTracks.length) return;
+
+          let gMin = Infinity;
+          let gMax = -Infinity;
+          if (globalScale) {
+            const allVals = visibleTracks
+              .flatMap((t) => filterByDate(t.points))
+              .filter((p) => p.dose !== 0 || p.cps !== 0)
+              .map((p) => (metric === "dose" ? p.dose : p.cps));
+            if (allVals.length) {
+              gMin = Math.min(...allVals);
+              gMax = Math.max(...allVals);
+            } else {
+              gMin = gMax = 0;
+            }
+          }
 
           trackDotLayer.addTo(map);
           visibleTracks.forEach((t) => {
             if (!t.markerGroup) t.markerGroup = L.layerGroup();
             else t.markerGroup.clearLayers();
 
-            filterByDate(t.points).forEach((p) => {
+            const pts = filterByDate(t.points);
+            let min = gMin;
+            let max = gMax;
+            if (!globalScale) {
+              const vals = pts
+                .filter((p) => p.dose !== 0 || p.cps !== 0)
+                .map((p) => (metric === "dose" ? p.dose : p.cps));
+              if (vals.length) {
+                min = Math.min(...vals);
+                max = Math.max(...vals);
+              } else {
+                min = max = 0;
+              }
+            }
+
+            pts.forEach((p) => {
               const valMetric = metric === "dose" ? p.dose : p.cps;
               const color =
                 p.dose === 0 && p.cps === 0
@@ -1620,6 +1723,15 @@
             dotOpacity = v;
             updateLineStyles();
           }
+        });
+        colormapSelect.addEventListener("change", (e) => {
+          colorMap = e.target.value;
+          drawDots();
+          renderTrackDots();
+        });
+        globalColorToggle.addEventListener("change", (e) => {
+          globalScale = e.target.checked;
+          renderTrackDots();
         });
         showSiteCirclesToggle.addEventListener("change", (e) => {
           showSiteCircles = e.target.checked;


### PR DESCRIPTION
## Summary
- add colormap select dropdown and global scale toggle to map sidebar
- support several colormaps and global/per-track color scaling
- hook up event listeners to update rendering

## Testing
- `npm test` *(fails: Missing script)*
- `node --check map.js`

------
https://chatgpt.com/codex/tasks/task_e_688d396f0554832db5d0cd19f2e88047