### PR TITLE
Enable global scale for aggregate map

### DIFF
--- a/map.html
+++ b/map.html
@@ -1576,11 +1576,24 @@
             return;
           }
           const points = aggregatePoints(visiblePoints);
-          const filteredVals = points.filter((p) => p.dose !== 0 || p.cps !== 0);
-          const sample = filteredVals.length ? filteredVals : points;
-          const vals = sample.map((p) => (metric === "dose" ? p.dose : p.cps));
-          const min = Math.min(...vals);
-          const max = Math.max(...vals);
+          let min, max;
+          if (globalScale) {
+            const vals = visiblePoints
+              .filter((p) => p.dose !== 0 || p.cps !== 0)
+              .map((p) => (metric === "dose" ? p.dose : p.cps));
+            if (vals.length) {
+              min = Math.min(...vals);
+              max = Math.max(...vals);
+            } else {
+              min = max = 0;
+            }
+          } else {
+            const filteredVals = points.filter((p) => p.dose !== 0 || p.cps !== 0);
+            const sample = filteredVals.length ? filteredVals : points;
+            const vals = sample.map((p) => (metric === "dose" ? p.dose : p.cps));
+            min = Math.min(...vals);
+            max = Math.max(...vals);
+          }
 
           const decimals = metric === "dose" ? 3 : 1;
           legendLabel.textContent =
@@ -1755,6 +1768,7 @@
         globalColorToggle.addEventListener("change", (e) => {
           globalScale = e.target.checked;
           renderTrackDots();
+          drawDots();
         });
         showSiteCirclesToggle.addEventListener("change", (e) => {
           showSiteCircles = e.target.checked;

--- a/map.js
+++ b/map.js
@@ -904,13 +904,24 @@ window.addEventListener("load", () => {
       return;
     }
     const points = aggregatePoints(visiblePoints);
-    const filteredVals = points.filter(
-      (p) => p.dose !== 0 || p.cps !== 0
-    );
-    const sample = filteredVals.length ? filteredVals : points;
-    const vals = sample.map((p) => (metric === "dose" ? p.dose : p.cps));
-    const min = Math.min(...vals);
-    const max = Math.max(...vals);
+    let min, max;
+    if (globalScale) {
+      const vals = visiblePoints
+        .filter((p) => p.dose !== 0 || p.cps !== 0)
+        .map((p) => (metric === "dose" ? p.dose : p.cps));
+      if (vals.length) {
+        min = Math.min(...vals);
+        max = Math.max(...vals);
+      } else {
+        min = max = 0;
+      }
+    } else {
+      const filteredVals = points.filter((p) => p.dose !== 0 || p.cps !== 0);
+      const sample = filteredVals.length ? filteredVals : points;
+      const vals = sample.map((p) => (metric === "dose" ? p.dose : p.cps));
+      min = Math.min(...vals);
+      max = Math.max(...vals);
+    }
 
     const legendLabel = document.getElementById("legend-label");
     const legendBar = document.getElementById("legend-bar");
@@ -1078,6 +1089,7 @@ window.addEventListener("load", () => {
   globalColorToggle.addEventListener("change", (e) => {
     globalScale = e.target.checked;
     renderTrackDots();
+    drawDots();
   });
   showTrackDotsToggle.addEventListener("change", (e) => {
     showTrackDots = e.target.checked;


### PR DESCRIPTION
## Summary
- apply global scale option to aggregated dots when track view is off
- refresh aggregated dots when the global scale toggle changes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d3c92bd00832db3502ff6c1158b70