### PR TITLE
Filter malformed rows in track CSV/TSV parsing

### DIFF
--- a/map.html
+++ b/map.html
@@ -739,12 +739,12 @@
             skipEmptyLines: true,
           });
 
+          const rows = parsed.data.filter((r) => r.length >= 7);
+
           let points;
-          if (parsed.data[0] && parsed.data[0].length > 6) {
+          if (rows[0] && rows[0].length > 6) {
             // RCTRK-style: timestamp, time, lat, lon, accuracy, dose, cps, ...
-            points = parsed.data
-              .filter((r) => r.length >= 7)
-              .map((r) => {
+            points = rows.map((r) => {
                 const lat = +r[2];
                 const lon = +r[3];
                 const dose = +r[5];


### PR DESCRIPTION
## Summary
- Filter out rows with fewer than seven fields when loading CSV/TSV track files
- Detect RCTRK-style files and map coordinates from this filtered row set

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688fe5b156f4832db6f178ee55f35d0d