### PR TITLE
feat: allow per-site icon selection

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -42,6 +42,7 @@
           <form id="siteForm" class="bg-gray-800 p-4 rounded space-y-2">
             <input id="siteId" placeholder="ID" class="w-full bg-gray-700 rounded px-2 py-1" required />
             <input id="title" placeholder="Title" class="w-full bg-gray-700 rounded px-2 py-1" required />
+            <input id="icon" placeholder="Icon (emoji)" value="🏠" class="w-full bg-gray-700 rounded px-2 py-1" />
             <div class="grid grid-cols-2 gap-2">
               <input id="lat" type="number" step="any" placeholder="Lat" class="bg-gray-700 rounded px-2 py-1" required />
               <input id="lon" type="number" step="any" placeholder="Lon" class="bg-gray-700 rounded px-2 py-1" required />
@@ -71,7 +72,7 @@
           .join('');
           div.innerHTML = `
             <div class="flex items-center justify-between">
-              <span>${s.id} - ${s.title}</span>
+              <span>${(s.icon || '🏠')} ${s.id} - ${s.title}</span>
               <div class="space-x-2"><button data-id="${s.id}" class="editSite bg-blue-600 hover:bg-blue-500 px-2 py-1 rounded text-sm">Edit</button> <button data-id="${s.id}" class="deleteSite bg-red-600 hover:bg-red-500 px-2 py-1 rounded">Delete</button></div>
             </div>
             <div class="flex flex-wrap gap-2">${imgs}</div>
@@ -131,16 +132,17 @@
         sec.querySelector('#siteForm').addEventListener('submit', async e => {
           e.preventDefault();
           const f = e.target;
-          const site = {
-            id: f.siteId.value.trim(),
-            title: f.title.value.trim(),
-            lat: +f.lat.value,
-            lon: +f.lon.value,
-            description: f.description.value.trim(),
-            images: editingSite && editingSite.images ? editingSite.images : [],
-            captions: Array.from(document.querySelectorAll('#imageCaptions .captionInput')).map(i => i.value.trim()),
-            references: f.references.value.split(',').map(s=>s.trim()).filter(Boolean)
-          };
+            const site = {
+              id: f.siteId.value.trim(),
+              title: f.title.value.trim(),
+              icon: f.icon.value.trim() || '🏠',
+              lat: +f.lat.value,
+              lon: +f.lon.value,
+              description: f.description.value.trim(),
+              images: editingSite && editingSite.images ? editingSite.images : [],
+              captions: Array.from(document.querySelectorAll('#imageCaptions .captionInput')).map(i => i.value.trim()),
+              references: f.references.value.split(',').map(s=>s.trim()).filter(Boolean)
+            };
           await fetch('/api/sites', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -157,11 +159,12 @@
         const f = document.getElementById('siteForm');
         f.siteId.value = site.id;
         f.siteId.disabled = true;
-        f.title.value = site.title;
-        f.lat.value = site.lat;
-        f.lon.value = site.lon;
-        f.description.value = site.description || '';
-        f.references.value = (site.references || []).join(', ');
+          f.title.value = site.title;
+          f.icon.value = site.icon || '🏠';
+          f.lat.value = site.lat;
+          f.lon.value = site.lon;
+          f.description.value = site.description || '';
+          f.references.value = (site.references || []).join(', ');
         renderCaptions(site);
         document.getElementById('siteFormSave').textContent = 'Update';
         document.getElementById('siteFormCancel').classList.remove('hidden');

--- a/map.html
+++ b/map.html
@@ -575,12 +575,13 @@
         const siteLayer = L.layerGroup().addTo(map);
         const trackListElem = document.getElementById("trackList");
         const siteListElem = document.getElementById("siteList");
-        const siteIcon = L.divIcon({
-          html: "🏠",
-          className: "site-icon",
-          iconSize: [24, 24],
-          iconAnchor: [12, 12],
-        });
+          const makeSiteIcon = (icon) =>
+            L.divIcon({
+              html: icon,
+              className: "site-icon",
+              iconSize: [24, 24],
+              iconAnchor: [12, 12],
+            });
         const siteMarkers = {};
         const sidebar = document.getElementById("sidebar");
         const trackViewToggle = document.getElementById("trackViewToggle");
@@ -1116,8 +1117,8 @@
           const sites = await fetchSites();
           sites.forEach((s) => {
             if (isNaN(s.lat) || isNaN(s.lon)) return;
-            const id = s.id || `${s.lat},${s.lon}`;
-            const m = L.marker([s.lat, s.lon], { icon: siteIcon }).addTo(siteLayer);
+              const id = s.id || `${s.lat},${s.lon}`;
+              const m = L.marker([s.lat, s.lon], { icon: makeSiteIcon(s.icon || '🏠') }).addTo(siteLayer);
             siteMarkers[id] = m;
             let html = `<div class='prose prose-sm prose-invert'><h3 class='font-semibold mb-1'>${s.title ?? ""}</h3>`;
             if (s.description) html += `<h4>Description</h4><p>${s.description}</p>`;
@@ -1187,11 +1188,14 @@
             checkbox.className = "siteCheck accent-blue-500";
             checkbox.dataset.id = id;
             checkbox.checked = true;
-            const labelElem = document.createElement("label");
-            labelElem.className = "flex items-center gap-2 text-gray-200";
-            labelElem.appendChild(checkbox);
-            labelElem.appendChild(document.createTextNode(" " + (s.title || id)));
-            li.appendChild(labelElem);
+              const labelElem = document.createElement("label");
+              labelElem.className = "flex items-center gap-2 text-gray-200";
+              labelElem.appendChild(checkbox);
+              const iconSpan = document.createElement("span");
+              iconSpan.textContent = s.icon || "🏠";
+              labelElem.appendChild(iconSpan);
+              labelElem.appendChild(document.createTextNode(" " + (s.title || id)));
+              li.appendChild(labelElem);
             const btn = document.createElement("button");
             btn.type = "button";
             btn.textContent = "↦";


### PR DESCRIPTION
## Summary
- let admins pick a custom icon for each site
- display chosen icons on the map and in the site list

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688fe7a6d770832db79c2a10b0ea3afe