### PR TITLE
Normalize dot colors per track

### DIFF
--- a/map.html
+++ b/map.html
@@ -1579,11 +1579,6 @@
         /* ------------------ DOT RENDER ------------------ */
         function drawDots() {
           const legend = document.getElementById("legend");
-          const legendLabel = document.getElementById("legend-label");
-          const legendBar = document.getElementById("legend-bar");
-          const legendMin = document.getElementById("legend-min");
-          const legendMax = document.getElementById("legend-max");
-
           if (trackView) {
             pointLayer.clearLayers();
             legend.classList.add("hidden");
@@ -1591,25 +1586,26 @@
           }
 
           const metric = document.getElementById("metricSelect").value;
-          const visiblePoints = filterByDate(allPoints).filter(
-            (p) => tracks[p.fname]?.visible
-          );
           const visibleTrackArr = Object.values(tracks).filter((t) => t.visible);
           const singleTrack =
             visibleTrackArr.length === 1 ? visibleTrackArr[0] : null;
-          if (!visiblePoints.length) {
+          if (!visibleTrackArr.length) {
             pointLayer.clearLayers();
-            legendLabel.textContent =
-              metric === "dose" ? "Dose (µSv/h)" : "Rate (cps)";
-            legendMin.textContent = "0";
-            legendMax.textContent = "0";
-            legendBar.style.background = "linear-gradient(to right, #777, #777)";
-            legend.classList.remove("hidden");
+            legend.classList.add("hidden");
             return;
           }
-          const points = aggregatePoints(visiblePoints);
+          let points = [];
           let min, max;
           if (globalScale) {
+            const visiblePoints = filterByDate(allPoints).filter(
+              (p) => tracks[p.fname]?.visible
+            );
+            if (!visiblePoints.length) {
+              pointLayer.clearLayers();
+              legend.classList.add("hidden");
+              return;
+            }
+            points = aggregatePoints(visiblePoints);
             const vals = visiblePoints
               .filter((p) => p.dose !== 0 || p.cps !== 0)
               .map((p) => (metric === "dose" ? p.dose : p.cps));
@@ -1619,30 +1615,62 @@
             } else {
               min = max = 0;
             }
+            points = points.map((p) => ({ ...p, _min: min, _max: max }));
           } else {
-            const filteredVals = points.filter((p) => p.dose !== 0 || p.cps !== 0);
-            const sample = filteredVals.length ? filteredVals : points;
-            const vals = sample.map((p) => (metric === "dose" ? p.dose : p.cps));
-            min = Math.min(...vals);
-            max = Math.max(...vals);
+            visibleTrackArr.forEach((t) => {
+              const raw = filterByDate(t.points);
+              const pts = aggregatePoints(raw);
+              const vals = raw
+                .filter((p) => p.dose !== 0 || p.cps !== 0)
+                .map((p) => (metric === "dose" ? p.dose : p.cps));
+              let tMin, tMax;
+              if (vals.length) {
+                tMin = Math.min(...vals);
+                tMax = Math.max(...vals);
+              } else {
+                tMin = tMax = 0;
+              }
+              points.push(
+                ...pts.map((p) => ({ ...p, _min: tMin, _max: tMax }))
+              );
+              if (singleTrack === t) {
+                min = tMin;
+                max = tMax;
+              }
+            });
           }
-
-          const decimals = metric === "dose" ? 3 : 1;
-          legendLabel.textContent =
-            metric === "dose" ? "Dose (µSv/h)" : "Rate (cps)";
-          legendMin.textContent = min.toFixed(decimals);
-          legendMax.textContent = max.toFixed(decimals);
-          const cMin = colorScale(min, min, max);
-          const cMid = colorScale((min + max) / 2, min, max);
-          const cMax = colorScale(max, min, max);
-          legendBar.style.background = `linear-gradient(to right, ${cMin}, ${cMid}, ${cMax})`;
-          legend.classList.remove("hidden");
+          if (!points.length) {
+            pointLayer.clearLayers();
+            legend.classList.add("hidden");
+            return;
+          }
+          if (globalScale || singleTrack) {
+            const legendLabel = document.getElementById("legend-label");
+            const legendBar = document.getElementById("legend-bar");
+            const legendMin = document.getElementById("legend-min");
+            const legendMax = document.getElementById("legend-max");
+            const decimals = metric === "dose" ? 3 : 1;
+            legendLabel.textContent =
+              metric === "dose" ? "Dose (µSv/h)" : "Rate (cps)";
+            legendMin.textContent = min.toFixed(decimals);
+            legendMax.textContent = max.toFixed(decimals);
+            const cMin = colorScale(min, min, max);
+            const cMid = colorScale((min + max) / 2, min, max);
+            const cMax = colorScale(max, min, max);
+            legendBar.style.background = `linear-gradient(to right, ${cMin}, ${cMid}, ${cMax})`;
+            legend.classList.remove("hidden");
+          } else {
+            legend.classList.add("hidden");
+          }
 
           pointLayer.clearLayers();
           const radius = 4 + map.getZoom() / 2;
           points.forEach((p) => {
             const valMetric = metric === "dose" ? p.dose : p.cps;
-            const color = p.dose === 0 && p.cps === 0 ? "#777" : colorScale(valMetric, min, max);
+            const color =
+              p.dose === 0 && p.cps === 0
+                ? "#777"
+                : colorScale(valMetric, p._min, p._max);
             const marker = L.circleMarker([p.lat, p.lon], {
               radius,
               renderer: map.getRenderer(map),

--- a/map.js
+++ b/map.js
@@ -924,8 +924,9 @@ window.addEventListener("load", () => {
       points = points.map((p) => ({ ...p, _min: min, _max: max }));
     } else {
       visibleTrackArr.forEach((t) => {
-        const pts = aggregatePoints(filterByDate(t.points));
-        const vals = pts
+        const raw = filterByDate(t.points);
+        const pts = aggregatePoints(raw);
+        const vals = raw
           .filter((p) => p.dose !== 0 || p.cps !== 0)
           .map((p) => (metric === "dose" ? p.dose : p.cps));
         let tMin, tMax;


### PR DESCRIPTION
## Summary
- derive per-track min/max from raw track data when coloring dots
- compute legend only for global scale or single-track context

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688fee69f698832dab0dccc453f585d0