### PR TITLE
Default to OSM map and adjust marker styling

### DIFF
--- a/map.html
+++ b/map.html
@@ -79,8 +79,9 @@
         pointer-events: none;
       }
       .track-line,
-      .glass-dot {
-        filter: drop-shadow(0 0 2px #000);
+      .glass-dot,
+      .track-marker {
+        filter: drop-shadow(0 0 3px #000);
       }
       .site-icon {
         font-size: 24px;
@@ -260,12 +261,12 @@
               <span>Show range</span>
             </label>
             <div>
-              <label for="siteRadiusSlider" class="block mb-1 font-medium">Radius (m): <span id="siteRadiusVal">200</span></label>
-              <input type="range" id="siteRadiusSlider" min="50" max="1000" value="200" step="10" class="w-full accent-blue-500" />
+              <label for="siteRadiusSlider" class="block mb-1 font-medium">Radius (m): <span id="siteRadiusVal">30</span></label>
+              <input type="range" id="siteRadiusSlider" min="30" max="1000" value="30" step="10" class="w-full accent-blue-500" />
               <div class="flex gap-2 text-xs mt-1">
                 <div class="flex-1">
                   <label>Min
-                    <input type="number" id="siteRadiusMin" value="50" class="w-full bg-gray-700 border border-gray-600 rounded px-1 py-0.5" />
+                    <input type="number" id="siteRadiusMin" value="30" class="w-full bg-gray-700 border border-gray-600 rounded px-1 py-0.5" />
                   </label>
                 </div>
                 <div class="flex-1">
@@ -318,7 +319,7 @@
                 <option value="dark">Dark</option>
                 <option value="light">Light</option>
                 <option value="topo">Topographic</option>
-                <option value="osm">OSM</option>
+                <option value="osm" selected>OSM</option>
                 <option value="hot">OSM HOT</option>
                 <option value="satellite">Satellite</option>
               </select>
@@ -479,7 +480,7 @@
 
       window.addEventListener("load", () => {
         const styleElem = document.createElement("style");
-        styleElem.textContent = `.track-line, .glass-dot { filter: drop-shadow(0 0 2px #000); }`;
+        styleElem.textContent = `.track-line, .glass-dot, .track-marker { filter: drop-shadow(0 0 3px #000); }`;
         document.head.appendChild(styleElem);
         /* ------------------ MAP ------------------ */
         const map = L.map("map", {
@@ -516,8 +517,8 @@
             { maxZoom: 20, attribution: "&copy; OpenStreetMap contributors, HOT" }
           ),
         };
-        let currentBase = baseLayers.dark.addTo(map);
-        let baseIsDark = true;
+        let currentBase = baseLayers.osm.addTo(map);
+        let baseIsDark = false;
         document.getElementById("basemapSelect").addEventListener("change", (e) => {
           const key = e.target.value;
           if (baseLayers[key]) {
@@ -1029,7 +1030,7 @@
                   ? "#777"
                   : colorScale(valMetric, min, max);
               const m = L.circleMarker([p.lat, p.lon], {
-                radius: 3,
+                radius: 2,
                 color,
                 fillColor: color,
                 weight: 1,
@@ -1664,7 +1665,7 @@
           }
 
           pointLayer.clearLayers();
-          const radius = 4 + map.getZoom() / 2;
+          const radius = 3 + map.getZoom() / 2;
           points.forEach((p) => {
             const valMetric = metric === "dose" ? p.dose : p.cps;
             const color =

--- a/map.js
+++ b/map.js
@@ -6,7 +6,7 @@ const FALLBACK_TRACK_FILES = [
 window.addEventListener("load", () => {
   const styleElem = document.createElement("style");
   styleElem.textContent =
-    `.track-line, .glass-dot { filter: drop-shadow(0 0 2px #000); }\n#trackPopup { backdrop-filter: blur(8px) saturate(150%); -webkit-backdrop-filter: blur(8px) saturate(150%); }`;
+    `.track-line, .glass-dot, .track-marker { filter: drop-shadow(0 0 3px #000); }\n#trackPopup { backdrop-filter: blur(8px) saturate(150%); -webkit-backdrop-filter: blur(8px) saturate(150%); }`;
   document.head.appendChild(styleElem);
   /* ------------------ MAP ------------------ */
   const map = L.map("map", {
@@ -51,8 +51,8 @@ window.addEventListener("load", () => {
       }
     ),
   };
-  let currentBase = baseLayers.dark.addTo(map);
-  let baseIsDark = true;
+  let currentBase = baseLayers.osm.addTo(map);
+  let baseIsDark = false;
   document.getElementById("basemapSelect").addEventListener("change", (e) => {
     const key = e.target.value;
     if (baseLayers[key]) {
@@ -515,7 +515,7 @@ window.addEventListener("load", () => {
             ? "#777"
             : colorScale(valMetric, min, max);
         const m = L.circleMarker([p.lat, p.lon], {
-          radius: 3,
+          radius: 2,
           color,
           fillColor: color,
           weight: 1,
@@ -969,7 +969,7 @@ window.addEventListener("load", () => {
     }
 
     pointLayer.clearLayers();
-    const radius = 4 + map.getZoom() / 2;
+    const radius = 3 + map.getZoom() / 2;
     points.forEach((p) => {
       const valMetric = metric === "dose" ? p.dose : p.cps;
       const color =


### PR DESCRIPTION
## Summary
- Set OpenStreetMap as the default basemap and preselect it in the map style dropdown
- Reduce data point radius and track dot size while adding a stronger shadow for better contrast
- Start site range slider at 30 m

## Testing
- `npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_688ff1dae9c4832d892a98bd4521ff17