### PR TITLE
Use maxima for map cell coloring

### DIFF
--- a/map.html
+++ b/map.html
@@ -937,6 +937,8 @@
                   lon: 0,
                   dose: 0,
                   cps: 0,
+                  maxDose: -Infinity,
+                  maxCps: -Infinity,
                   energy: 0,
                   eCount: 0,
                   dateSum: 0,
@@ -948,6 +950,8 @@
             c.lon += p.lon;
             c.dose += p.dose;
             c.cps += p.cps;
+            c.maxDose = Math.max(c.maxDose, p.dose);
+            c.maxCps = Math.max(c.maxCps, p.cps);
             if (Number.isFinite(p.energy) && p.energy > 0) {
               c.energy += p.energy;
               c.eCount++;
@@ -965,6 +969,8 @@
               lon: c.lon / c.count,
               dose: c.dose / c.count,
               cps: c.cps / c.count,
+              maxDose: c.maxDose,
+              maxCps: c.maxCps,
               energy: c.eCount ? c.energy / c.eCount : NaN,
               date: c.dateCount ? c.dateSum / c.dateCount : NaN,
             });
@@ -1607,9 +1613,9 @@
               return;
             }
             points = aggregatePoints(visiblePoints);
-            const vals = visiblePoints
-              .filter((p) => p.dose !== 0 || p.cps !== 0)
-              .map((p) => (metric === "dose" ? p.dose : p.cps));
+            const vals = points
+              .filter((p) => p.maxDose !== 0 || p.maxCps !== 0)
+              .map((p) => (metric === "dose" ? p.maxDose : p.maxCps));
             if (vals.length) {
               min = Math.min(...vals);
               max = Math.max(...vals);
@@ -1621,9 +1627,9 @@
             visibleTrackArr.forEach((t) => {
               const raw = filterByDate(t.points);
               const pts = aggregatePoints(raw);
-              const vals = raw
-                .filter((p) => p.dose !== 0 || p.cps !== 0)
-                .map((p) => (metric === "dose" ? p.dose : p.cps));
+              const vals = pts
+                .filter((p) => p.maxDose !== 0 || p.maxCps !== 0)
+                .map((p) => (metric === "dose" ? p.maxDose : p.maxCps));
               let tMin, tMax;
               if (vals.length) {
                 tMin = Math.min(...vals);
@@ -1667,9 +1673,9 @@
           pointLayer.clearLayers();
           const radius = 3 + map.getZoom() / 2;
           points.forEach((p) => {
-            const valMetric = metric === "dose" ? p.dose : p.cps;
+            const valMetric = metric === "dose" ? p.maxDose : p.maxCps;
             const color =
-              p.dose === 0 && p.cps === 0
+              p.maxDose === 0 && p.maxCps === 0
                 ? "#777"
                 : colorScale(valMetric, p._min, p._max);
             const marker = L.circleMarker([p.lat, p.lon], {

--- a/map.js
+++ b/map.js
@@ -422,6 +422,8 @@ window.addEventListener("load", () => {
             lon: 0,
             dose: 0,
             cps: 0,
+            maxDose: -Infinity,
+            maxCps: -Infinity,
             energy: 0,
             eCount: 0,
             dateSum: 0,
@@ -433,6 +435,8 @@ window.addEventListener("load", () => {
       c.lon += p.lon;
       c.dose += p.dose;
       c.cps += p.cps;
+      c.maxDose = Math.max(c.maxDose, p.dose);
+      c.maxCps = Math.max(c.maxCps, p.cps);
       if (Number.isFinite(p.energy) && p.energy > 0) {
         c.energy += p.energy;
         c.eCount++;
@@ -450,6 +454,8 @@ window.addEventListener("load", () => {
         lon: c.lon / c.count,
         dose: c.dose / c.count,
         cps: c.cps / c.count,
+        maxDose: c.maxDose,
+        maxCps: c.maxCps,
         energy: c.eCount ? c.energy / c.eCount : NaN,
         date: c.dateCount ? c.dateSum / c.dateCount : NaN,
       });
@@ -912,9 +918,9 @@ window.addEventListener("load", () => {
         return;
       }
       points = aggregatePoints(visiblePoints);
-      const vals = visiblePoints
-        .filter((p) => p.dose !== 0 || p.cps !== 0)
-        .map((p) => (metric === "dose" ? p.dose : p.cps));
+      const vals = points
+        .filter((p) => p.maxDose !== 0 || p.maxCps !== 0)
+        .map((p) => (metric === "dose" ? p.maxDose : p.maxCps));
       if (vals.length) {
         min = Math.min(...vals);
         max = Math.max(...vals);
@@ -926,9 +932,9 @@ window.addEventListener("load", () => {
       visibleTrackArr.forEach((t) => {
         const raw = filterByDate(t.points);
         const pts = aggregatePoints(raw);
-        const vals = raw
-          .filter((p) => p.dose !== 0 || p.cps !== 0)
-          .map((p) => (metric === "dose" ? p.dose : p.cps));
+        const vals = pts
+          .filter((p) => p.maxDose !== 0 || p.maxCps !== 0)
+          .map((p) => (metric === "dose" ? p.maxDose : p.maxCps));
         let tMin, tMax;
         if (vals.length) {
           tMin = Math.min(...vals);
@@ -971,9 +977,9 @@ window.addEventListener("load", () => {
     pointLayer.clearLayers();
     const radius = 3 + map.getZoom() / 2;
     points.forEach((p) => {
-      const valMetric = metric === "dose" ? p.dose : p.cps;
+      const valMetric = metric === "dose" ? p.maxDose : p.maxCps;
       const color =
-        p.dose === 0 && p.cps === 0
+        p.maxDose === 0 && p.maxCps === 0
           ? "#777"
           : colorScale(valMetric, p._min, p._max);
       const marker = L.circleMarker([p.lat, p.lon], {


### PR DESCRIPTION
## Summary
- track maximum dose and cps for each aggregated cell
- color map cells based on maximum readings rather than averages

## Testing
- `node --check map.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68952c0213e0832da7c3836cc915faa5