### PR TITLE
Normalize track dose units to µSv/h

### DIFF
--- a/map.html
+++ b/map.html
@@ -697,12 +697,18 @@
             const js = JSON.parse(text);
             const markers = Array.isArray(js) ? js : js.markers;
             if (Array.isArray(markers)) {
-              const factor = js.sv === false ? 0.01 : 1;
+              const unit = (js.unit || js.units || "").toLowerCase();
+              const factor = js.sv === false || unit.includes("ur") ? 0.01 : 1;
+              const getDose = (m) => {
+                if (m.dose_uSv_h != null) return +m.dose_uSv_h;
+                if (m.dose_uR_h != null) return +m.dose_uR_h * 0.01;
+                return +(m.doseRate ?? m.dose ?? 0) * factor;
+              };
               const points = markers
                 .map((m) => ({
                   lat: +m.lat,
                   lon: +m.lon,
-                  dose: +(m.doseRate ?? m.dose_uSv_h ?? m.dose ?? 0) * factor,
+                  dose: getDose(m),
                   cps: +(m.countRate ?? m.cps ?? 0),
                   energy: +(m.energy ?? m.energyValue ?? m.energy_ev ?? NaN),
                   date: +m.date || 0,
@@ -719,14 +725,24 @@
               const objs = lines.map((l) => JSON.parse(l));
               if (objs.every((o) => typeof o === "object")) {
                 const points = objs
-                  .map((m) => ({
-                    lat: +m.lat,
-                    lon: +m.lon,
-                    dose: +(m.doseRate ?? m.dose_uSv_h ?? m.dose ?? 0),
-                    cps: +(m.countRate ?? m.cps ?? 0),
-                    energy: +(m.energy ?? m.energyValue ?? m.energy_ev ?? NaN),
-                    date: +m.date || 0,
-                  }))
+                  .map((m) => {
+                    const unit = (m.unit || m.units || "").toLowerCase();
+                    const factor = m.sv === false || unit.includes("ur") ? 0.01 : 1;
+                    const dose =
+                      m.dose_uSv_h != null
+                        ? +m.dose_uSv_h
+                        : m.dose_uR_h != null
+                        ? +m.dose_uR_h * 0.01
+                        : +(m.doseRate ?? m.dose ?? 0) * factor;
+                    return {
+                      lat: +m.lat,
+                      lon: +m.lon,
+                      dose,
+                      cps: +(m.countRate ?? m.cps ?? 0),
+                      energy: +(m.energy ?? m.energyValue ?? m.energy_ev ?? NaN),
+                      date: +m.date || 0,
+                    };
+                  })
                   .filter((p) => !isNaN(p.lat) && !isNaN(p.lon));
                 return { points };
               }
@@ -742,14 +758,20 @@
           });
 
           const rows = parsed.data.filter((r) => r.length >= 7);
+          let factor = 1;
+          if (rows.length && typeof rows[0][5] === "string") {
+            const header = rows.shift();
+            if (header[5].toLowerCase().includes("ur")) factor = 0.01;
+          }
 
           let points;
           if (rows[0] && rows[0].length > 6) {
             // RCTRK-style: timestamp, time, lat, lon, accuracy, dose, cps, ...
-            points = rows.map((r) => {
+            points = rows
+              .map((r) => {
                 const lat = +r[2];
                 const lon = +r[3];
-                const dose = +r[5];
+                const dose = +r[5] * factor;
                 const cps = +r[6];
                 let date = 0;
                 const ts = Number(r[0]);
@@ -769,7 +791,7 @@
               .map((r) => ({
                 lat: +r[0],
                 lon: +r[1],
-                dose: +r[2],
+                dose: +r[2] * factor,
                 cps: +r[3],
                 energy: +r[4] || NaN,
                 date: 0,


### PR DESCRIPTION
## Summary
- Detect and convert track doses reported in uR/h to µSv/h
- Apply unit normalization for JSON and CSV track formats

## Testing
- `node --check map.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68952f260e30832d8e7ea28d984320ee