### PR TITLE
Allow unit selection and correct radiation dose conversions

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -221,12 +221,16 @@
             <input type="file" name="file" accept=".rctrk" class="w-full bg-gray-700 rounded" required />
             <input name="title" placeholder="Title" class="w-full bg-gray-700 rounded px-2 py-1" />
             <textarea name="description" rows="2" placeholder="Description" class="w-full bg-gray-700 rounded px-2 py-1"></textarea>
+            <select name="unit" class="w-full bg-gray-700 rounded px-2 py-1">
+              <option value="usv">µSv/h</option>
+              <option value="ur">µR/h</option>
+            </select>
             <button class="bg-green-600 hover:bg-green-500 px-4 py-1 rounded">Upload</button>
           </form>`;
         const list = sec.querySelector('#trackList');
         list.innerHTML = '';
         tracks.forEach(t => {
-          const track = typeof t === 'string' ? { file: t, title: '', description: '' } : t;
+          const track = typeof t === 'string' ? { file: t, title: '', description: '', unit: 'usv' } : t;
           const div = document.createElement('div');
           div.className = 'bg-gray-800 p-4 rounded space-y-2';
           div.innerHTML = `
@@ -236,6 +240,10 @@
             </div>
             <input data-file="${track.file}" class="trackTitle w-full bg-gray-700 rounded px-2 py-1" placeholder="Title" value="${track.title || ''}" />
             <textarea data-file="${track.file}" class="trackDesc w-full bg-gray-700 rounded px-2 py-1" rows="2" placeholder="Description">${track.description || ''}</textarea>
+            <select data-file="${track.file}" class="trackUnit w-full bg-gray-700 rounded px-2 py-1">
+              <option value="usv" ${track.unit === 'ur' ? '' : 'selected'}>µSv/h</option>
+              <option value="ur" ${track.unit === 'ur' ? 'selected' : ''}>µR/h</option>
+            </select>
             <button data-file="${track.file}" class="saveTrack bg-blue-600 hover:bg-blue-500 px-2 py-1 rounded text-sm">Save</button>`;
           list.appendChild(div);
         });
@@ -255,10 +263,11 @@
             const div = btn.parentElement;
             const title = div.querySelector('.trackTitle').value;
             const description = div.querySelector('.trackDesc').value;
+            const unit = div.querySelector('.trackUnit').value;
             await fetch('/api/tracks', {
               method: 'PUT',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ file: btn.dataset.file, title, description })
+              body: JSON.stringify({ file: btn.dataset.file, title, description, unit })
             });
           });
         });

--- a/map.html
+++ b/map.html
@@ -688,7 +688,9 @@
             const data = await res.json();
             return Array.isArray(data)
               ? data.map((t) =>
-                  typeof t === "string" ? { file: t, title: "", description: "" } : t
+                  typeof t === "string"
+                    ? { file: t, title: "", description: "", unit: "usv" }
+                    : { unit: t.unit || "usv", ...t }
                 )
               : [];
           } catch {
@@ -696,21 +698,21 @@
             errorMessage.textContent =
               "Could not fetch track_index.json, using fallback list.";
             errorMessage.classList.remove("hidden");
-            return FALLBACK_TRACK_FILES.map((f) => ({ file: f, title: "", description: "" }));
+            return FALLBACK_TRACK_FILES.map((f) => ({ file: f, title: "", description: "", unit: "usv" }));
           }
         };
 
-        const parseFile = (text) => {
+        const parseFile = (text, defaultUnit = "") => {
           // .rctrk JSON (object with markers or plain array)
           try {
             const js = JSON.parse(text);
             const markers = Array.isArray(js) ? js : js.markers;
             if (Array.isArray(markers)) {
-              const unit = js.unit || js.units || "";
+              const unit = js.unit || js.units || defaultUnit || "";
               const factor = doseUnitFactor(unit, js.sv);
               const getDose = (m) => {
                 if (m.dose_uSv_h != null) return +m.dose_uSv_h;
-                if (m.dose_uR_h != null) return +m.dose_uR_h * 0.01;
+                if (m.dose_uR_h != null) return +m.dose_uR_h * doseUnitFactor("ur");
                 return +(m.doseRate ?? m.dose ?? 0) * factor;
               };
               const points = markers
@@ -735,13 +737,13 @@
               if (objs.every((o) => typeof o === "object")) {
                 const points = objs
                   .map((m) => {
-                    const unit = m.unit || m.units || "";
+                    const unit = m.unit || m.units || defaultUnit || "";
                     const factor = doseUnitFactor(unit, m.sv);
                     const dose =
                       m.dose_uSv_h != null
                         ? +m.dose_uSv_h
                         : m.dose_uR_h != null
-                        ? +m.dose_uR_h * 0.01
+                        ? +m.dose_uR_h * doseUnitFactor("ur")
                         : +(m.doseRate ?? m.dose ?? 0) * factor;
                     return {
                       lat: +m.lat,
@@ -767,10 +769,10 @@
           });
 
           const rows = parsed.data.filter((r) => r.length >= 7);
-          let factor = 1;
+          let factor = doseUnitFactor(defaultUnit);
           if (rows.length && typeof rows[0][5] === "string") {
             const header = rows.shift();
-            factor = doseUnitFactor(header[5]);
+            factor = doseUnitFactor(header[5] || defaultUnit);
           }
 
           let points;
@@ -1272,7 +1274,7 @@
             try {
               const res = await fetch(fname);
               if (!res.ok) throw new Error(`HTTP ${res.status}`);
-              const { points: pts, title: fileTitle } = parseFile(await res.text());
+              const { points: pts, title: fileTitle } = parseFile(await res.text(), item.unit);
               const metaTitle = item.title || '';
               const description = item.description || '';
               const title = metaTitle || fileTitle || fname.split("/").pop();

--- a/server.js
+++ b/server.js
@@ -78,7 +78,9 @@ app.get('/api/tracks', requireAuth, (req, res) => {
   let index = readJson('track_index.json');
   if (Array.isArray(index)) {
     index = index.map((t) =>
-      typeof t === 'string' ? { file: t, title: '', description: '' } : t
+      typeof t === 'string'
+        ? { file: t, title: '', description: '', unit: 'usv' }
+        : { unit: t.unit || 'usv', ...t }
     );
   } else {
     index = [];
@@ -95,7 +97,8 @@ app.post('/api/tracks', requireAuth, trackStorage.single('file'), (req, res) => 
   const entry = {
     file: filePath,
     title: req.body.title || '',
-    description: req.body.description || ''
+    description: req.body.description || '',
+    unit: req.body.unit || 'usv'
   };
   index.push(entry);
   writeJson('track_index.json', index);
@@ -103,12 +106,12 @@ app.post('/api/tracks', requireAuth, trackStorage.single('file'), (req, res) => 
 });
 
 app.put('/api/tracks', requireAuth, (req, res) => {
-  const { file, title = '', description = '' } = req.body;
+  const { file, title = '', description = '', unit = 'usv' } = req.body;
   let index = readJson('track_index.json');
   if (!Array.isArray(index)) index = [];
   index = index.map((t) => {
     if ((typeof t === 'string' ? t : t.file) === file) {
-      return { file, title, description };
+      return { file, title, description, unit };
     }
     return t;
   });

--- a/update_track_index.js
+++ b/update_track_index.js
@@ -10,7 +10,7 @@ const trackFiles = fs
   .readdirSync(DATA_DIR)
   .filter(f => f.toLowerCase().endsWith('.rctrk'))
   .sort()
-  .map(f => ({ file: `data/${f}`, title: '', description: '' }));
+  .map(f => ({ file: `data/${f}`, title: '', description: '', unit: 'usv' }));
 
 fs.writeFileSync(indexPath, JSON.stringify(trackFiles, null, 2) + '\n');
 console.log(`Updated ${indexPath} with ${trackFiles.length} track file(s)`);


### PR DESCRIPTION
## Summary
- Let admins choose track dose units in the dashboard and persist this choice on the server
- Parse track files with unit metadata and use the correct µR→µSv conversion factor
- Include unit field in track index generator

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check map.js server.js update_track_index.js`


------
https://chatgpt.com/codex/tasks/task_e_6897080a5988832d8a68ffcf506ac4a0